### PR TITLE
Add bower configuration

### DIFF
--- a/component.json
+++ b/component.json
@@ -1,0 +1,10 @@
+{
+  "name": "angularFire",
+  "version": "0.0.1",
+  "main": "./angularFire.js",
+  "dependencies": {
+    "angular": "1.0.5"
+  },
+  "readmeFilename": "README.md",
+  "description": "AngularJS bindings for Firebase."
+}


### PR DESCRIPTION
Add support for managing angularFire dependency via [bower](https://github.com/twitter/bower). If this is accepted/merged, it would be a good idea to register the package via `bower register`.

It feels weird making this pull request against the `gh-pages` branch, but I see no alternatives.
