### PR TITLE
Bugfix: Account for the 4th argument of angularFire()

### DIFF
--- a/angularFire.js
+++ b/angularFire.js
@@ -6,9 +6,9 @@ angular.module('firebase', []).value('Firebase', Firebase);
 // synchronized with a Firebase location both ways.
 // TODO: Optimize to use child events instead of whole 'value'.
 angular.module('firebase').factory('angularFire', function($q) {
-  return function(url, scope, name) {
+  return function(url, scope, name, ret) {
     var af = new AngularFire($q, url);
-    return af.associate(scope, name);
+    return af.associate(scope, name, ret);
   };
 });
 


### PR DESCRIPTION
The 4th argument of service angularFire specifies the desired type of the object.
The service didn't pass the argument to AngularFire.prototype.associate.
