### PR TITLE
Bugfix: angularFire() returned undefined when value is already cached.

### DIFF
--- a/angularFire.js
+++ b/angularFire.js
@@ -25,6 +25,7 @@ AngularFire.prototype = {
       ret = [];
     }
     var deferred = this._q.defer();
+    var promise = deferred.promise;
     this._fRef.on('value', function(snap) {
       var resolve = false;
       if (deferred) {
@@ -52,7 +53,7 @@ AngularFire.prototype = {
       self._safeApply($scope,
         self._resolve.bind(self, $scope, name, resolve, self._remoteValue));
     });
-    return deferred.promise;
+    return promise;
   },
   _resolve: function($scope, name, deferred, val) {
     $scope[name] = angular.copy(val);


### PR DESCRIPTION
First let me say that I'm not completely sure about the intended logic of the variable `deferred`.

But I experienced this problem: If the value is already cached then the callback given in `this._fRef.on ()` will be called immediately. This will set `deferred` to false, so `return deferred.promise` will return undefined instead of the intended promise.
