### PR TITLE
Fix bad index lookups in remove and update

### DIFF
--- a/angularFire.js
+++ b/angularFire.js
@@ -187,12 +187,12 @@ angular.module('firebase').factory('angularFireCollection', function($timeout) {
       collectionRef.push(item, cb ? cb : null);
     };
     collection.remove = function(itemOrId) {
-      var item = angular.isString(itemOrId) ? collection[itemOrId] : itemOrId;
+      var item = angular.isString(itemOrId) ? collection[indexes[itemOrId]] : itemOrId;
       item.$ref.remove();
     };
 
     collection.update = function(itemOrId) {
-      var item = angular.isString(itemOrId) ? collection[itemOrId] : itemOrId;
+      var item = angular.isString(itemOrId) ? collection[indexes[itemOrId]] : itemOrId;
       var copy = {};
       angular.forEach(item, function(value, key) {
         if (key.indexOf('$') !== 0) {


### PR DESCRIPTION
When passed the ID of an item, `collection.remove` and `collection.update` finds the item in the collection via `collection[itemOrId]`, which doesn't appear to be correct as `collection` is an array and `itemOrId` is the ID of the item at an unknown index. This pull request patches these methods to use `collection[indexes[itemOrId]]` instead.
