### PR TITLE
Use Angular $parse service to assign values in $scope

### DIFF
--- a/angularFire.js
+++ b/angularFire.js
@@ -2,13 +2,14 @@
 
 angular.module('firebase', []).factory('angularFire', function($q) {
   return function(url, scope, name) {
-    var af = new AngularFire($q, url);
+    var af = new AngularFire($q, $parse, url);
     return af.associate(scope, name);
   };
 });
 
-function AngularFire($q, url) {
+function AngularFire($q, $parse, url) {
   this._q = $q;
+  this._parse = $parse;
   this._initial = true;
   this._remoteValue = false;
   this._fRef = new Firebase(url);
@@ -38,7 +39,7 @@ AngularFire.prototype = {
   },
   _resolve: function($scope, name, deferred, val) {
     console.log("remote change");
-    $scope[name] = angular.copy(val);
+    this._parse(name).assign($scope, angular.copy(val));
     this._remoteValue = angular.copy(val);
     if (deferred) {
       console.log("resolving deferred");


### PR DESCRIPTION
Model value assignment in `_resolve` works correctly only with models at the top level of `$scope`. When the synchronized model is referenced as `"name['key']"` or `"a.b.c[10]"`, then `$watch` tracks the changes in the correct models: `$scope.name['key']` or `$scope.a.b.c[10]`, but updates from Firebase would be assigned to wrong ones: `$scope["name['key']"]` or `$scope["a.b.c[10]"]`.

The modified code uses Angular `$parse` service to assign the correct model within the `$scope` even if it belongs to an object or array.

The update replaces the following line in `_resolve`:

```
    $scope[name] = angular.copy(val);
```

with

```
    this._parse(name).assign($scope, angular.copy(val));
```

Reference to $parse service is passed to AngularFire as a parameter.
