### PR TITLE
Fix broken indexes after remove

### DIFF
--- a/angularFire.js
+++ b/angularFire.js
@@ -163,8 +163,9 @@ angular.module('firebase').factory('angularFireCollection', ['$timeout', functio
     collectionRef.on('child_removed', function(data) {
       $timeout(function() {
         var id = data.name();
+        var pos = indexes[id];
         removeChild(id);
-        updateIndexes(indexes[id]);
+        updateIndexes(pos);
       });
     });
 


### PR DESCRIPTION
Notice that removeChild removes the index,
so updateIndexes will always get undefined as
the 'from' parameter. As a consequence,
the indexes never get updated on remove.
This can be reproduced in the following way:
remove the 0th element from a collection,
this will cause the index go inconsistent,
and consequent removals will lead
to a broken state.
This is a trivial fix that I tested
to fix the problem in my use case.
