### PR TITLE
return the $id of the added object when calling add() on angularFireCollection

### DIFF
--- a/angularFire.js
+++ b/angularFire.js
@@ -203,11 +203,13 @@ angular.module('firebase').factory('angularFireCollection', ['$timeout', functio
     });
 
     collection.add = function(item, cb) {
+      var ref;
       if (!cb) {
-        collectionRef.ref().push(item);
+        ref = collectionRef.ref().push(item);
       } else {
-        collectionRef.ref().push(item, cb);
+        ref = collectionRef.ref().push(item, cb);
       }
+      return ref.name();
     };
     collection.remove = function(itemOrId) {
       var item = angular.isString(itemOrId) ? collection[indexes[itemOrId]] : itemOrId;


### PR DESCRIPTION
TL;DR: Bring the semantics of angularFireCollection.add() a bit closer to that of Firebase.push().

This change set allows you to reference the added object by it's uniquely-generated (by Firebase) $id. This can be useful, for example, if one controller adds a new object and then passes control to another controller that wants to pull that object out of firebase using its $id.
