### PR TITLE
Use Angular $parse service to get named values from $scope

### DIFF
--- a/angularFire.js
+++ b/angularFire.js
@@ -56,7 +56,7 @@ AngularFire.prototype = {
           return;
         }
         self._remoteValue = angular.copy(val);
-        if (angular.equals(val, $scope[name])) {
+        if (angular.equals(val, self._parse(name)($scope))) {
           return;
         }
       }
@@ -87,7 +87,7 @@ AngularFire.prototype = {
         self._initial = false;
         return;
       }
-      var val = JSON.parse(angular.toJson($scope[name]));
+      var val = JSON.parse(angular.toJson(self._parse(name)($scope)));
       if (angular.equals(val, self._remoteValue)) {
         return;
       }


### PR DESCRIPTION
Use of `$scope[name]` works only if name is simply a property identifier (denoting an object in `$scope`).
It does not work if the bound object is a deeper sub-object of $scope, like `$scope.foo[42].bar`

@Newtrin0 already fixed the _assignment_ to the named object, see #18.
This commit now corrects also the _reading_ of the named object, fixing an error message triggered by updates received from Firebase. This should finally allow for binding objects deep in the scope.

(I changed only the unminified version, so minimization remains to be performed.)
