### PR TITLE
Add bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,8 @@
+{
+  "name": "angular-fire",
+  "version": "0.1.0",
+  "main": "./angularFire.js",
+  "dependencies": {
+    "angular": "1.0.7"
+  }
+}


### PR DESCRIPTION
I've registered angularFire to [bower registry](http://sindresorhus.com/bower-components/) as `angular-fire`. You can install angularFire now through Bower already via `bower install angular-fire`.

Although it already works as is, this `bower.json` will make it works better with Bower by defining a dependency to AngularJS.

For concerns that were mentioned in #3, what I'd say is that you can always add Firebase dependency into `bower.json` later once you've found the proper solution. Since it looks like Firebase distribution is stuck with your own CDN server for now, however, I suspect this solution will be taking some time to find, and this PR is what we can do best about this topic for now IMHO.
