### PR TITLE
Added priority attribute to angularFireItems for easy sorting

### DIFF
--- a/angularFire.js
+++ b/angularFire.js
@@ -104,7 +104,7 @@ angular.module('firebase').factory('angularFireCollection', ['$timeout', functio
     this.$ref = ref.ref();
     this.$id = ref.name();
     this.$index = index;
-      angular.extend(this, ref.val(),{priority:ref.getPriority()});
+      angular.extend(this, {priority:ref.getPriority()}, ref.val());
   }
 
   return function(collectionUrlOrRef, initialCb) {


### PR DESCRIPTION
Firebase items can be optionally ordered by priority, however this functionality is not reflected in angularFireCollections. This addition allows you to take advantage of angular's orderBy filter: http://docs.angularjs.org/api/ng.filter:orderBy
