### PR TITLE
Use $location.replace to avoid history spam from login redirects

### DIFF
--- a/angularFire.js
+++ b/angularFire.js
@@ -289,6 +289,7 @@ angular.module("firebase").factory("angularFireAuth", [
               } else {
                 self._redirectTo = next.pathTo === options.path ? "/" : next.pathTo;
               }
+              $location.replace();
               $location.path(options.path);
             }
           });
@@ -364,6 +365,7 @@ angular.module("firebase").factory("angularFireAuth", [
         updateExpression(this._scope, this._name, user, function() {
           $rootScope.$broadcast("angularFireAuth:login", user);
           if (self._redirectTo) {
+            $location.replace();
             $location.path(self._redirectTo);
             self._redirectTo = null;
           }


### PR DESCRIPTION
As I am integrating the new `angularFireAuth`, I noticed the back button getting harder and harder to use with login redirects filling up my browser history. I've added `$location.replace()` calls before the redirects to avoid this issue. I'm not sure if this matches your philosophy, but it feels cleaner and more natural to me.
