### PR TITLE
Fixed callback in createUser function to pass back error along with user

### DIFF
--- a/angularFire.js
+++ b/angularFire.js
@@ -526,7 +526,7 @@ angular.module("firebase").factory("angularFireAuth", [
           }
           if (cb) {
             $timeout(function(){
-              cb(user);
+              cb(err, user);
             });
           }
         });


### PR DESCRIPTION
Minor fix: It looks like the callback in the `createUser` function isn't passing back the `err` along with the `user` object.
