### PR TITLE
chore(grunt): adds load-grunt-tasks module

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -65,11 +65,7 @@ module.exports = function(grunt) {
 
   });
 
-  grunt.loadNpmTasks('grunt-contrib-uglify');
-  grunt.loadNpmTasks('grunt-contrib-jshint');
-  grunt.loadNpmTasks('grunt-exec');
-  grunt.loadNpmTasks('grunt-contrib-watch');
-  grunt.loadNpmTasks('grunt-notify');
+  require('load-grunt-tasks')(grunt);
 
   grunt.registerTask('build', ['jshint', 'uglify']);
   grunt.registerTask('test', ['exec:casperjs']);

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "grunt-notify": "~0.2.7",
     "grunt-contrib-watch": "~0.5.1",
     "grunt-contrib-jshint": "~0.6.2",
-    "grunt-exec": "~0.4.2"
+    "grunt-exec": "~0.4.2",
+    "load-grunt-tasks": "~0.2.0"
   }
 }


### PR DESCRIPTION
makes it way more easier to maintain grunt plugin loading
