### PR TITLE
chore(grunt): adds grunt-conventional-changelog plugin

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -61,6 +61,12 @@ module.exports = function(grunt) {
           message: 'Build Finished'
         }
       }
+    },
+
+    changelog: {
+      options: {
+        dest: 'CHANGELOG.md'
+      }
     }
 
   });
@@ -70,6 +76,7 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-exec');
   grunt.loadNpmTasks('grunt-contrib-watch');
   grunt.loadNpmTasks('grunt-notify');
+  grunt.loadNpmTasks('grunt-conventional-changelog');
 
   grunt.registerTask('build', ['jshint', 'uglify']);
   grunt.registerTask('test', ['exec:casperjs']);

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "grunt-notify": "~0.2.7",
     "grunt-contrib-watch": "~0.5.1",
     "grunt-contrib-jshint": "~0.6.2",
-    "grunt-exec": "~0.4.2"
+    "grunt-exec": "~0.4.2",
+    "grunt-conventional-changelog": "~1.0.0"
   }
 }


### PR DESCRIPTION
this plugin lets you auto-generate changelogs based on given commit
history

you commit messages have to follow the same conventions that are used
in this commit

for more information see http://github.com/btford/grunt-conventional-changelog
