### PR TITLE
_loggedIn() was not setting self._authenticated (caused `authRequired` routes to always redirect, even when logged in)

### DIFF
--- a/angularfire.js
+++ b/angularfire.js
@@ -598,6 +598,7 @@ AngularFireAuth.prototype = {
     var self = this;
     self._timeout(function() {
       self._object.user = user;
+      self._authenticated = true;
       self._rootScope.$broadcast("$firebaseAuth:login", user);
       if (self._redirectTo) {
         self._location.replace();


### PR DESCRIPTION
_loggedIn() was not setting self._authenticated (caused `authRequired` routes to always redirect, even when logged in)
