### PR TITLE
Remove `./angularfire.min.js` from bower.json's `main` array.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "angularfire",
   "version": "0.5.0",
-  "main": ["./angularfire.js", "./angularfire.min.js"],
+  "main": ["./angularfire.js"],
   "ignore": ["Gruntfile.js", "package.js", "tests", "README.md", ".travis.yml"],
   "dependencies": {
     "angular": "~1.2.0",


### PR DESCRIPTION
Having both the regular and the minified version of the JS file in `main` leads to inclusion of both in the HTML file when a build tool like [grunt-bower-install](https://github.com/stephenplusplus/grunt-bower-install) is used.
