### PR TITLE
Add missing call to .ref() before calling .update()

### DIFF
--- a/angularfire.js
+++ b/angularfire.js
@@ -603,7 +603,7 @@
       // If the local model is an object, call an update to set local values.
       var local = self._parse(name)(scope);
       if (local !== undefined && typeof local == "object") {
-        self._fRef.update(self._parseObject(local));
+        self._fRef.ref().update(self._parseObject(local));
       }
 
       // We're responsible for setting up scope.$watch to reflect local changes


### PR DESCRIPTION
Without this adjustment, angularFire will throw the following error when updating the limit of a Query.
`Object #<H> has no method 'update'` 

I'm assuming that's because .update() isn't available on the Query reference, only on the base reference.
