### PR TITLE
fix to address problem comparison in watch when a priority has been set previously.

### DIFF
--- a/angularfire.js
+++ b/angularfire.js
@@ -618,7 +618,6 @@
           return;
 	} else if (angular.equals(local,  self._parseObject(self._object))) {
           return;
-          return;
         }
 
         // If the local model is undefined or the remote data hasn't been


### PR DESCRIPTION
I was experiencing some strange race conditions and unnecessary "set" commands being fired and started to investigate. I have not deciphered all of AngularFire's internal approach to the watch being set as a result of binding. However, there appears to be a bug with objects stored in Firebase that have a priority set on them previously.

Without this code change the check for changes in the watch function will always evaluate to true because the local object will never evaluate to equal to the self._object  for objects that have a pre-existing priority because the self._object will have a "$priority" and the local will have a ".priority".

The change suggested below fixes it.
