### PR TITLE
Change observe-js to official bower version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,6 +8,6 @@
     "angular-mocks" : "~1.2.0",
     "firebase": "~1.0.2",
     "firebase-simple-login": "~1.2.3",
-    "observe-js": "https://github.com/jeffbcross/observe-js.git"
+    "observe-js": "~0.1.4"
   }
 }


### PR DESCRIPTION
i think this should work now, and fixes some warnings while the bower install process.

ps: sorry my last pull request was from master, please ignore it.
