### PR TITLE
Extend not replace existing children

### DIFF
--- a/angularfire.js
+++ b/angularfire.js
@@ -552,7 +552,12 @@
       if (value == null) {
         delete this._object[key];
       } else {
-        this._object[key] = value;
+        if (typeof this._object[key] != "object") {
+          this._object[key] = value;
+        }
+        else {
+          angular.extend(this._object[key], value);
+        }
       }
 
       // Call change handlers.


### PR DESCRIPTION
Currently, if I do `var currentChild = parents[currentChildID];`, the binding between currentChild and parents[currentChildID] is lost whenever the child at currentChildID is updated, because it's value is simply being overwritten (creating a new object).  This change fixes that, keeping all references in sync throughout the app.
