### PR TITLE
$firebase objects act like a promise (#247)

### DIFF
--- a/angularfire.js
+++ b/angularfire.js
@@ -427,9 +427,10 @@
       // Act like a then-able
       object.then = function(success) {
         var deferred = self._q.defer();
-        var onLoad = function () {
+        var onLoad = function() {
+          object.then = null;
+          object.$off("loaded", onLoad);
           deferred.resolve(object);
-          object.$off("loaded", load);
         };
         object.$on("loaded", onLoad);
         return deferred.promise.then(success);

--- a/tests/unit/AngularFire.spec.js
+++ b/tests/unit/AngularFire.spec.js
@@ -1,11 +1,10 @@
 describe('AngularFire', function () {
    var $firebase, $filter, $timeout;
    beforeEach(module('firebase'));
-   beforeEach(inject(function (_$firebase_, _$filter_, _$timeout_, _$rootScope_) {
+   beforeEach(inject(function (_$firebase_, _$filter_, _$timeout_) {
       $firebase = _$firebase_;
       $filter = _$filter_;
       $timeout = _$timeout_;
-      $rootScope = _$rootScope_;
    }));
 
    describe('$on', function() {
@@ -134,10 +133,12 @@ describe('AngularFire', function () {
    describe('then', function () {
 
     it('calls the handler on data load', function () {
-      var fb = new Firebase('Mock://').child('data').autoFlush(), spy = jasmine.createSpy();
-      $firebase(fb).then(spy);
-      flush();
+      var fb = new Firebase('Mock://').child('data'), spy = jasmine.createSpy();
+      var $fb = $firebase(fb);
+      $fb.then(spy);
+      flush(fb);
       expect(spy.callCount).toBe(1);
+      expect(spy).toHaveBeenCalledWith($fb);
     });
 
    });


### PR DESCRIPTION
Raised in #247 

This is incomplete — still having trouble getting the test to pass. Assuming it has something to do with the way the mock events are being flushed, but the usual way of flushing pending $q promises (`$rootScope.$digest`) doesn't work.
