### PR TITLE
Make `$firebase` into a provider and allow object transformation be defined

### DIFF
--- a/angularfire.js
+++ b/angularfire.js
@@ -22,7 +22,7 @@
   // Define the `$firebase` service that provides synchronization methods.
   angular.module("firebase").provider("$firebase", function() {
     var self = this,
-        identityFn = function(input) {return input};
+        identityFn = function(input) {return input;};
 
     this.transform = {
       onSave: identityFn,
@@ -567,7 +567,7 @@
 
       Obj[key] = value;
       newObj = self._transform.onLoad(Obj);
-      for (var newKey in newObj) break;
+      for (var newKey in newObj) {break;}
 
       if (newObj[newKey] == null) {
         delete this._object[newKey];


### PR DESCRIPTION
Usage:

``` javascript
angular.module('myApp', ['firebase']).

config(function(
  $firebaseProvider
){
  // Applies when client is saving to Firebase
  $firebaseProvider.transform.onSave = ...

  // Applies when client is loading from Firebase
  $firebaseProvider.transform.onLoad = ...
});
```

Example (together with `angular-object-key`):

``` javascript
angular.module('myApp', ['firebase', 'ObjectKey']).

config(function(
  $firebaseProvider,
  ObjectKey
){
  $firebaseProvider.transform = {
    onSave: function(object) {
      return ObjectKey.toSnakeCase(object, {
        except: /^-/
      });
    },
    onLoad: function(object) {
      return ObjectKey.toCamelCase(object, {
        except: /^-/
      });
    }
  };
});
```

One thing to bear in mind is that unlike `$http`'s `transformResponse`, which is from JSON to Object, both `onSave` and `onLoad` are Object-in-Object-out, because it works better with Firebase's central concept.
