### PR TITLE
Make `$firebase` a provider and allow API extension

### DIFF
--- a/angularfire.js
+++ b/angularfire.js
@@ -430,9 +430,11 @@
         return self._fRef.ref();
       };
 
-      self._fns && angular.forEach(self._fns, function(fn, name) {
-        object[name] = fn;
-      });
+      if (self._fns) {
+        angular.forEach(self._fns, function(fn, name) {
+          object[name] = fn;
+        });
+      }
 
       self._object = object;
       self._getInitialValue();


### PR DESCRIPTION
As discussed in [#298](https://github.com/firebase/angularFire/pull/298#issuecomment-40464000), this PR offers a way to extend the API so that these newly added methods can be enjoyed by `$child` references as well.
