### PR TITLE
Provide npm scripts for build tasks and use in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ branches:
 install:
   - git clone git://github.com/n1k0/casperjs.git ~/casperjs
   - export PATH=$PATH:~/casperjs/bin
-  - npm install -g grunt-cli
   - npm install -g bower
   - npm install
   - bower install
@@ -15,4 +14,5 @@ before_script:
   - phantomjs --version
   - casperjs --version
 script:
-  - grunt
+  - npm test
+  - npm run-script build

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "0.7.1",
   "description": "An officially supported AngularJS binding for Firebase.",
   "main": "angularfire.js",
+  "scripts": {
+    "test": "grunt test",
+    "build": "grunt build"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/firebase/angularFire.git"
@@ -31,6 +35,7 @@
     "karma-chrome-launcher": "~0.1.0",
     "protractor": "~0.12.1",
     "lodash": "~2.4.1",
-    "karma-safari-launcher": "~0.1.1"
+    "karma-safari-launcher": "~0.1.1",
+    "grunt-cli": "~0.1.13"
   }
 }


### PR DESCRIPTION
See related discussion on `npm i -D grunt-cli` on https://github.com/assemble/assemble/pull/515

This uses `npm test` to run `grunt test` in keeping with npm conventions
