### PR TITLE
Move mockfirebase to devDeps

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -32,11 +32,11 @@
   "dependencies": {
     "angular": "1.2.x || 1.3.x",
     "firebase": "1.0.x",
-    "firebase-simple-login": "1.6.x",
-    "mockfirebase": "~0.2.9"
+    "firebase-simple-login": "1.6.x"
   },
   "devDependencies": {
     "lodash": "~2.4.1",
-    "angular-mocks": "~1.2.18"
+    "angular-mocks": "1.2.x || 1.3.x",
+    "mockfirebase": "~0.3.0"
   }
 }


### PR DESCRIPTION
shouldn't be `mockfirebase` a devDep?  bower installs this with angularFire and wiredep puts it to my index.html.
