### PR TITLE
Fixed bug from calling $logout() multiple times

### DIFF
--- a/src/firebaseSimpleLogin.js
+++ b/src/firebaseSimpleLogin.js
@@ -94,14 +94,13 @@
 
     // Unauthenticate the Firebase reference.
     logout: function() {
-      if (this._currentUserData) {
-        // Tell the simple login client to log us out.
-        this._authClient.logout();
+      // Tell the simple login client to log us out.
+      this._authClient.logout();
 
-        // Forget who we were, so that any getCurrentUser calls will wait for
-        // another user event.
-        delete this._currentUserData;
-      }
+      // Forget who we were immediately, so that any getCurrentUser() calls
+      // will resolve the user as logged out even before the _onLoginEvent()
+      // fires and resets this._currentUserData to null again.
+      this._currentUserData = null;
     },
 
     // Creates a user for Firebase Simple Login. Function 'cb' receives an


### PR DESCRIPTION
@katowulf - This fixes #431. We used to set `this._currentUserData` to `undefined` every time `$logout()` was called. This worked in most cases since the called to `this._authClient.logout()` ended up firing out `_onLoginEvent()` callback which set `this._currentUserData` to `null` and resolved any leftover `getCurrentUser()` promises. However, if we called `this._authClient.logout()` when we were already logged out, Simple Login does not fire the `_onLoginEvent()` callback and `this._currentUserData` gets stuck as `undefined`, which causes problems for logging in and getting the current user. Having `this._currentUserData` as `undefined` should only be valid at the very initializing of this service. It should always otherwise be `null` or a valid user object. As a result, this change just sets it to `null` when we call `$logout()`.

cc/ @davideast 
