### PR TITLE
Manually add spies where used

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -37,6 +37,6 @@
   "devDependencies": {
     "lodash": "~2.4.1",
     "angular-mocks": "~1.2.18",
-    "mockfirebase": "0.3"
+    "mockfirebase": "~0.4.0"
   }
 }

--- a/tests/unit/FirebaseArray.spec.js
+++ b/tests/unit/FirebaseArray.spec.js
@@ -89,7 +89,7 @@ describe('$FirebaseArray', function () {
     it('should reject promise on fail', function() {
       var successSpy = jasmine.createSpy('resolve spy');
       var errSpy = jasmine.createSpy('reject spy');
-      $fb.$ref().push.and.returnValue($utils.reject('fail_push'));
+      spyOn($fb.$ref(), 'push').and.returnValue($utils.reject('fail_push'));
       arr.$add('its deed').then(successSpy, errSpy);
       flushAll();
       expect(successSpy).not.toHaveBeenCalled();

--- a/tests/unit/firebase.spec.js
+++ b/tests/unit/firebase.spec.js
@@ -138,6 +138,7 @@ describe('$firebase', function () {
     it('should work on a query', function() {
       var ref = new Firebase('Mock://').child('ordered').limit(5);
       var $fb = $firebase(ref);
+      spyOn(ref.ref(), 'push').and.callThrough();
       flushAll();
       expect(ref.ref().push).not.toHaveBeenCalled();
       $fb.$push({foo: 'querytest'});
@@ -202,6 +203,7 @@ describe('$firebase', function () {
     it('should affect query keys only if query used', function() {
       var ref = new Firebase('Mock://').child('ordered').limit(1);
       var $fb = $firebase(ref);
+      spyOn(ref.ref(), 'update');
       ref.flush();
       var expKeys = ref.slice().keys;
       $fb.$set({hello: 'world'});
@@ -276,6 +278,7 @@ describe('$firebase', function () {
     });
 
     it('should remove data in Firebase', function() {
+      spyOn($fb.$ref(), 'remove');
       $fb.$remove();
       flushAll();
       expect($fb.$ref().remove).toHaveBeenCalled();
@@ -291,6 +294,9 @@ describe('$firebase', function () {
       expect(origKeys.length).toBeGreaterThan(keys.length);
       var $fb = $firebase(ref);
       flushAll(ref);
+      origKeys.forEach(function (key) {
+        spyOn(ref.ref().child(key), 'remove');
+      });
       $fb.$remove();
       flushAll(ref);
       keys.forEach(function(key) {
@@ -546,8 +552,10 @@ describe('$firebase', function () {
     });
 
     it('should cancel listeners if destroyFn is invoked', function() {
-      var arr = $fb.$asArray();
       var ref = $fb.$ref();
+      spyOn(ref, 'on').and.callThrough();
+      spyOn(ref, 'off').and.callThrough();
+      var arr = $fb.$asArray();
       flushAll();
       expect(ref.on).toHaveBeenCalled();
       arr.$$$destroyFn();
@@ -651,8 +659,10 @@ describe('$firebase', function () {
     });
 
     it('should cancel listeners if destroyFn is invoked', function() {
-      var obj = $fb.$asObject();
       var ref = $fb.$ref();
+      spyOn(ref, 'on').and.callThrough();
+      spyOn(ref, 'off').and.callThrough();
+      var obj = $fb.$asObject();
       flushAll();
       expect(ref.on).toHaveBeenCalled();
       obj.$$$destroyFn();


### PR DESCRIPTION
Pending https://github.com/katowulf/mockfirebase/issues/27 so don't merge yet. Bower is currently pointing at a git branch and will need to be updated and rebased for an actual released tag. 

MockFirebase will be removing its behavior of looping all keys on each instance and spying on them. Spies are somewhat expensive to set up and execute and doing so was adding test overhead in the 100x range for MockFirebase and in the 3-10x range for dependents' test suites. 

I've gone ahead and made the very small number of required updates to explicitly spy on methods where needed. This brings the execution time for me on the Karma run from ~15s to ~5s. 
