### PR TITLE
Renamed utils.getSnapshotKey() to utils.getKey()

### DIFF
--- a/src/FirebaseArray.js
+++ b/src/FirebaseArray.js
@@ -256,14 +256,14 @@
          */
         $$added: function(snap, prevChild) {
           // check to make sure record does not exist
-          var i = this.$indexFor($firebaseUtils.getSnapshotKey(snap));
+          var i = this.$indexFor($firebaseUtils.getKey(snap));
           if( i === -1 ) {
             // parse data and create record
             var rec = snap.val();
             if( !angular.isObject(rec) ) {
               rec = { $value: rec };
             }
-            rec.$id = $firebaseUtils.getSnapshotKey(snap);
+            rec.$id = $firebaseUtils.getKey(snap);
             rec.$priority = snap.getPriority();
             $firebaseUtils.applyDefaults(rec, this.$$defaults);
 
@@ -279,7 +279,7 @@
          * @param snap
          */
         $$removed: function(snap) {
-          var rec = this.$getRecord($firebaseUtils.getSnapshotKey(snap));
+          var rec = this.$getRecord($firebaseUtils.getKey(snap));
           if( angular.isObject(rec) ) {
             this._process('child_removed', rec);
           }
@@ -292,7 +292,7 @@
          * @param snap
          */
         $$updated: function(snap) {
-          var rec = this.$getRecord($firebaseUtils.getSnapshotKey(snap));
+          var rec = this.$getRecord($firebaseUtils.getKey(snap));
           if( angular.isObject(rec) ) {
             // apply changes to the record
             var changed = $firebaseUtils.updateRec(rec, snap);
@@ -311,7 +311,7 @@
          * @param {string} prevChild
          */
         $$moved: function(snap, prevChild) {
-          var rec = this.$getRecord($firebaseUtils.getSnapshotKey(snap));
+          var rec = this.$getRecord($firebaseUtils.getKey(snap));
           if( angular.isObject(rec) ) {
             rec.$priority = snap.getPriority();
             this._process('child_moved', rec, prevChild);

--- a/src/FirebaseObject.js
+++ b/src/FirebaseObject.js
@@ -55,7 +55,7 @@
           value: this.$$conf
         });
 
-        this.$id = $firebaseUtils.getSnapshotKey($firebase.$ref().ref());
+        this.$id = $firebaseUtils.getKey($firebase.$ref().ref());
         this.$priority = null;
 
         $firebaseUtils.applyDefaults(this, this.$$defaults);

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -61,8 +61,8 @@
               // the entire Firebase path
               ref.once('value', function(snap) {
                 snap.forEach(function(ss) {
-                  if( !dataCopy.hasOwnProperty($firebaseUtils.getSnapshotKey(ss)) ) {
-                    dataCopy[$firebaseUtils.getSnapshotKey(ss)] = null;
+                  if( !dataCopy.hasOwnProperty($firebaseUtils.getKey(ss)) ) {
+                    dataCopy[$firebaseUtils.getKey(ss)] = null;
                   }
                 });
                 ref.ref().update(dataCopy, this._handle(def, ref));

--- a/src/utils.js
+++ b/src/utils.js
@@ -342,13 +342,13 @@
           },
 
           /**
-           * A utility for retrieving a DataSnapshot's key name. This
-           * is backwards-compatible with `name()` from Firebase 1.x.x
-           * and `key()` from Firebase 2.0.0+. Once support for Firebase
+           * A utility for retrieving a Firebase reference or DataSnapshot's
+           * key name. This is backwards-compatible with `name()` from Firebase
+           * 1.x.x and `key()` from Firebase 2.0.0+. Once support for Firebase
            * 1.x.x is dropped in AngularFire, this helper can be removed.
            */
-          getSnapshotKey: function(snapshot) {
-            return (typeof snapshot.key === 'function') ? snapshot.key() : snapshot.name();
+          getKey: function(refOrSnapshot) {
+            return (typeof refOrSnapshot.key === 'function') ? refOrSnapshot.key() : refOrSnapshot.name();
           },
 
           /**

--- a/tests/unit/utils.spec.js
+++ b/tests/unit/utils.spec.js
@@ -174,10 +174,10 @@ describe('$firebaseUtils', function () {
     });
   });
 
-  describe('#getSnapshotKey', function() {
+  describe('#getKey', function() {
     it('should return the key name given a DataSnapshot', function() {
       var snapshot = testutils.snap('data', 'foo');
-      expect($utils.getSnapshotKey(snapshot)).toEqual('foo');
+      expect($utils.getKey(snapshot)).toEqual('foo');
     });
   });
 


### PR DESCRIPTION
@katowulf - Minor change here. I renamed `getSnapshotKey()` to `getKey()` so that it could be used for both `Firebase` and `DataSnapshot` objects. I also have called in `getKey()` in our other bindings libraries.
