### PR TITLE
Simplify checkMetaVars $watch statement.

### DIFF
--- a/src/FirebaseObject.js
+++ b/src/FirebaseObject.js
@@ -25,7 +25,7 @@
    */
   angular.module('firebase').factory('$FirebaseObject', [
     '$parse', '$firebaseUtils', '$log', '$interval',
-    function($parse, $firebaseUtils, $log, $interval) {
+    function($parse, $firebaseUtils, $log) {
       /**
        * This constructor should probably never be called manually. It is used internally by
        * <code>$firebase.$asObject()</code>.


### PR DESCRIPTION
Per the [angular documentation](https://code.angularjs.org/1.2.26/docs/api/ng/type/$rootScope.Scope#$digest) the "magic" hack you are using to detect each digest cycles is unnecessary. Simply register a watch function with no watch expression.
From the documentation:

> If you want to be notified whenever `$digest()` is called, you can register a `watchExpression` function with `$watch()` with no listener.
