### PR TITLE
Add concat step to e2e test builds.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -95,12 +95,12 @@ module.exports = function(grunt) {
         configFile: 'tests/automatic_karma.conf.js'
       },
       manual: {
-        configFile: 'tests/manual_karma.conf.js',
+        configFile: 'tests/manual_karma.conf.js'
       },
       singlerun: {},
       watch: {
          autowatch: true,
-         singleRun: false,
+         singleRun: false
       },
       saucelabs: {
         configFile: 'tests/sauce_karma.conf.js'


### PR DESCRIPTION
Readme instructions don't work with new clones of the repo otherwise.
It's a good idea to make sure you've got a fresh concat of the sources before each protractor run anyways (or you risk testing stale code).
