### PR TITLE
Fix debounce usage in FirebaseObject

### DIFF
--- a/src/FirebaseObject.js
+++ b/src/FirebaseObject.js
@@ -334,11 +334,12 @@
               parsed.assign(scope, $firebaseUtils.scopeData(rec));
             }
 
+            var send = $firebaseUtils.debounce(function() {
+              rec.$$scopeUpdated(getScope())
+                ['finally'](function() { sending = false; });
+            }, 50, 500);
+
             var scopeUpdated = function() {
-              var send = $firebaseUtils.debounce(function() {
-                rec.$$scopeUpdated(getScope())
-                  ['finally'](function() { sending = false; });
-              }, 50, 500);
               if( !equals(rec) ) {
                 sending = true;
                 send();


### PR DESCRIPTION
A new debounced function was being created on every call to `scopeUpdated()`.
That's probably not what we want. Instead create it once and call the same
instance on every update.
