### PR TITLE
Fix: utils.debounce timing corner case.

### DIFF
--- a/tests/unit/utils.spec.js
+++ b/tests/unit/utils.spec.js
@@ -51,6 +51,42 @@ describe('$firebaseUtils', function () {
     });
   });
 
+  describe('#debounce', function(){
+    it('should trigger function with arguments',function(){
+      var spy = jasmine.createSpy();
+      $utils.debounce(spy,10)('foo', 'bar');
+      $timeout.flush();
+      expect(spy).toHaveBeenCalledWith('foo', 'bar');
+    });
+
+    it('should only trigger once, with most recent arguments',function(){
+      var spy = jasmine.createSpy();
+      var fn =  $utils.debounce(spy,10);
+      fn('foo', 'bar');
+      fn('baz', 'biz');
+      $timeout.flush();
+      expect(spy.calls.count()).toBe(1);
+      expect(spy).toHaveBeenCalledWith('baz', 'biz');
+    });
+
+    it('should only trigger once (timing corner case)',function(){
+      var spy = jasmine.createSpy();
+      var fn =  $utils.debounce(spy, null, 1, 2);
+      fn('foo', 'bar');
+      var start = Date.now();
+
+      // block for 3ms without releasing
+      while(Date.now() - start < 3){ }
+
+      fn('bar', 'baz');
+      fn('baz', 'biz');
+      expect(spy).not.toHaveBeenCalled();
+      $timeout.flush();
+      expect(spy.calls.count()).toBe(1);
+      expect(spy).toHaveBeenCalledWith('baz', 'biz');
+    });
+  });
+
   describe('#updateRec', function() {
     it('should return true if changes applied', function() {
       var rec = {};


### PR DESCRIPTION
Invocations of the debounced method between when `runNow` is scheduled
and when it actually runs will schedule additional `runNow` invocations
to be executed in rapid succession.

Also includes a few clarifications in the comments. A few comments copied from batch didn't make sense in the debounce method. Also, IMO the words `immediate` implies synchronous execution so I changed it to `next tick`.

I made similar changes to batch (the same problem existed there). I was able to write tests for my changes to debounce, but how to write a similar test for my changes to batch eludes me.
