### PR TITLE
Return uid of created user

### DIFF
--- a/src/FirebaseAuth.js
+++ b/src/FirebaseAuth.js
@@ -206,7 +206,7 @@
         if (error !== null) {
           deferred.reject(error);
         } else {
-          deferred.resolve(user && user.uid);
+          deferred.resolve(user);
         }
       });
 


### PR DESCRIPTION
@katowulf - As of 2.0.5, the Firebase client will return the `uid` of the newly created user, so people no longer need the login/logout hack. This PR updates AngularFire's `$createUser()` method to return this `user` object, which is a backwards-compatible change.
