### PR TITLE
Temporarily turn off SauceLabs testing

### DIFF
--- a/tests/travis.sh
+++ b/tests/travis.sh
@@ -1,6 +1,6 @@
 grunt build
 grunt test:unit
 if [ $SAUCE_ACCESS_KEY ]; then
-  grunt sauce:unit
+  #grunt sauce:unit
   #grunt sauce:e2e
 fi


### PR DESCRIPTION
@katowulf - We have already gone over our SauceLabs minutes for this "month" (not calendar month, but we do still have 15 days left in the "month"). I'm not sure if this is just due to the amount of PRs we are doing, but each Travis test does take a long time to complete. I don't know how much utility we are getting out of SauceLabs at the moment and we don't want to rack up overages. So let's temporarily disable SauceLabs ASAP and we can discuss a plan moving forward.

@bendrucker - I feel bad disabling this even temporarily since I appreciated this contribution and like the idea of it. In your experience with Travis + SauceLabs, do the test suites usually take 10-20 minutes to run? That is what I'm seeing on [AngularFire's Travis page](https://travis-ci.org/firebase/angularfire/builds). If so, that is rather disconcerting and SauceLabs seems like a very expensive option. Maybe we have something misconfigured?
