### PR TITLE
Update to MockFirebase 0.7

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -36,6 +36,6 @@
   "devDependencies": {
     "lodash": "~2.4.1",
     "angular-mocks": "~1.2.18",
-    "mockfirebase": "0.5.0"
+    "mockfirebase": "~0.7.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "karma-chrome-launcher": "^0.1.4",
     "karma-coverage": "^0.2.4",
     "karma-failed-reporter": "0.0.2",
+    "karma-html2js-preprocessor": "~0.1.0",
     "karma-jasmine": "~0.2.0",
     "karma-phantomjs-launcher": "~0.1.0",
     "karma-sauce-launcher": "~0.2.9",

--- a/tests/automatic_karma.conf.js
+++ b/tests/automatic_karma.conf.js
@@ -10,7 +10,8 @@ module.exports = function(config) {
     singleRun: true,
 
     preprocessors: {
-      "../src/*.js": "coverage"
+      "../src/*.js": "coverage",
+      "./fixtures/**/*.json": "html2js"
     },
 
     coverageReporter: {
@@ -34,6 +35,7 @@ module.exports = function(config) {
       '../src/module.js',
       '../src/**/*.js',
       'mocks/**/*.js',
+      "fixtures/**/*.json",
       'unit/**/*.spec.js'
     ]
   });

--- a/tests/fixtures/data.json
+++ b/tests/fixtures/data.json
@@ -1,0 +1,82 @@
+{
+  "data": {
+    "a": {
+      "aString": "alpha",
+      "aNumber": 1,
+      "aBoolean": false
+    },
+    "b": {
+      "aString": "bravo",
+      "aNumber": 2,
+      "aBoolean": true
+    },
+    "c": {
+      "aString": "charlie",
+      "aNumber": 3,
+      "aBoolean": true
+    },
+    "d": {
+      "aString": "delta",
+      "aNumber": 4,
+      "aBoolean": true
+    },
+    "e": {
+      "aString": "echo",
+      "aNumber": 5
+    }
+  },
+  "index": {
+    "b": true,
+    "c": 1,
+    "e": false,
+    "z": true
+  },
+  "ordered": {
+    "null_a": {
+      "aNumber": 0,
+      "aLetter": "a"
+    },
+    "null_b": {
+      "aNumber": 0,
+      "aLetter": "b"
+    },
+    "null_c": {
+      "aNumber": 0,
+      "aLetter": "c"
+    },
+    "num_1_a": {
+      ".priority": 1,
+      "aNumber": 1
+    },
+    "num_1_b": {
+      ".priority": 1,
+      "aNumber": 1
+    },
+    "num_2": {
+      ".priority": 2,
+      "aNumber": 2
+    },
+    "num_3": {
+      ".priority": 3,
+      "aNumber": 3
+    },
+    "char_a_1": {
+      ".priority": "a",
+      "aNumber": 1,
+      "aLetter": "a"
+    },
+    "char_a_2": {
+      ".priority": "a",
+      "aNumber": 2,
+      "aLetter": "a"
+    },
+    "char_b": {
+      ".priority": "b",
+      "aLetter": "b"
+    },
+    "char_c": {
+      ".priority": "c",
+      "aLetter": "c"
+    }
+  }
+}

--- a/tests/mocks/mocks.firebase.js
+++ b/tests/mocks/mocks.firebase.js
@@ -1,9 +1,5 @@
 
 angular.module('mock.firebase', [])
   .run(function($window) {
-    $window.mockfirebase.override();
-    $window.Firebase = $window.MockFirebase;
-  })
-  .factory('Firebase', function($window) {
-    return $window.MockFirebase;
+    $window.MockFirebase.override();
   });

--- a/tests/unit/FirebaseArray.spec.js
+++ b/tests/unit/FirebaseArray.spec.js
@@ -82,7 +82,7 @@ describe('$FirebaseArray', function () {
       var spy = jasmine.createSpy();
       arr.$add({foo: 'bar'}).then(spy);
       flushAll();
-      var lastId = $fb.$ref().getLastAutoId();
+      var lastId = $fb.$ref()._lastAutoId;
       expect(spy).toHaveBeenCalledWith($fb.$ref().child(lastId));
     });
 

--- a/tests/unit/firebase.spec.js
+++ b/tests/unit/firebase.spec.js
@@ -3,6 +3,8 @@ describe('$firebase', function () {
 
   var $firebase, $timeout, $rootScope, $utils;
 
+  var defaults = JSON.parse(window.__html__['fixtures/data.json']);
+
   beforeEach(function() {
     module('firebase');
     module('mock.firebase');
@@ -29,7 +31,10 @@ describe('$firebase', function () {
   describe('<constructor>', function() {
     var $fb;
     beforeEach(function() {
-      $fb = $firebase(new Firebase('Mock://').child('data'));
+      var ref = new Firebase('Mock://');
+      ref.set(defaults);
+      ref.flush();
+      $fb = $firebase(ref.child('data'));
     });
 
     it('should accept a Firebase ref', function() {
@@ -108,7 +113,7 @@ describe('$firebase', function () {
       var blackSpy = jasmine.createSpy('reject');
       $fb.$push({foo: 'bar'}).then(whiteSpy, blackSpy);
       flushAll();
-      var newId = $fb.$ref().getLastAutoId();
+      var newId = $fb.$ref()._lastAutoId;
       expect(whiteSpy).toHaveBeenCalled();
       expect(blackSpy).not.toHaveBeenCalled();
       var ref = whiteSpy.calls.argsFor(0)[0];
@@ -138,10 +143,8 @@ describe('$firebase', function () {
       var ref = new Firebase('Mock://').child('ordered').limit(5);
       var $fb = $firebase(ref);
       spyOn(ref.ref(), 'push').and.callThrough();
-      flushAll();
       expect(ref.ref().push).not.toHaveBeenCalled();
       $fb.$push({foo: 'querytest'});
-      flushAll();
       expect(ref.ref().push).toHaveBeenCalled();
     });
   });
@@ -203,7 +206,6 @@ describe('$firebase', function () {
       var ref = new Firebase('Mock://').child('ordered').limit(1);
       var $fb = $firebase(ref);
       spyOn(ref.ref(), 'update');
-      ref.flush();
       var expKeys = ref.slice().keys;
       $fb.$set({hello: 'world'});
       ref.flush();
@@ -216,6 +218,7 @@ describe('$firebase', function () {
     var $fb, flushAll;
     beforeEach(function() {
       $fb = $firebase(new Firebase('Mock://').child('data'));
+      $fb.$ref().set(defaults.data);
       flushAll = flush.bind(null, $fb.$ref());
     });
 
@@ -239,8 +242,7 @@ describe('$firebase', function () {
       var ref = new Firebase('Mock://').child('ordered').limit(2);
       var $fb = $firebase(ref);
       $fb.$remove().then(spy);
-      flushAll(ref);
-      flushAll(ref);
+      flush(ref);
       expect(spy).toHaveBeenCalledWith(ref);
     });
 
@@ -285,39 +287,47 @@ describe('$firebase', function () {
     });
 
     it('should only remove keys in query if used on a query', function() {
-      var ref = new Firebase('Mock://').child('ordered').limit(2);
-      var keys = ref.slice().keys;
-      var origKeys = ref.ref().getKeys();
+      var ref = new Firebase('Mock://').child('ordered')
+      var query = ref.limit(2);
+      ref.set(defaults.ordered);
+      ref.flush();
+      var keys = query.slice().keys;
+      var origKeys = query.ref().getKeys();
       expect(keys.length).toBeGreaterThan(0);
       expect(origKeys.length).toBeGreaterThan(keys.length);
-      var $fb = $firebase(ref);
-      flushAll(ref);
+      var $fb = $firebase(query);
       origKeys.forEach(function (key) {
-        spyOn(ref.ref().child(key), 'remove');
+        spyOn(query.ref().child(key), 'remove');
       });
       $fb.$remove();
-      flushAll(ref);
+      flushAll(query);
       keys.forEach(function(key) {
-        expect(ref.ref().child(key).remove).toHaveBeenCalled();
+        expect(query.ref().child(key).remove).toHaveBeenCalled();
       });
       origKeys.forEach(function(key) {
         if( keys.indexOf(key) === -1 ) {
-          expect(ref.ref().child(key).remove).not.toHaveBeenCalled();
+          expect(query.ref().child(key).remove).not.toHaveBeenCalled();
         }
       });
     });
 
     it('should wait to resolve promise until data is actually deleted',function(){
-      var ref = new Firebase('Mock://').child('ordered').limit(2);
-      var $fb = $firebase(ref);
+      var ref = new Firebase('Mock://').child('ordered');
+      ref.set(defaults.ordered);
+      ref.flush();
+      var query = ref.limit(2);
+      var $fb = $firebase(query);
       var resolved = false;
       $fb.$remove().then(function(){
         resolved = true;
       });
-      try {$timeout.flush();} catch(e){} //this may actually throw an error
       expect(resolved).toBe(false);
-      flushAll(ref);
-      flushAll(ref);
+      // flush once for on('value')
+      ref.flush();
+      // flush again to fire the ref#remove calls
+      ref.flush();
+      // then flush the promise
+      $timeout.flush();
       expect(resolved).toBe(true);
     });
   });
@@ -325,8 +335,11 @@ describe('$firebase', function () {
   describe('$update', function() {
     var $fb, flushAll;
     beforeEach(function() {
-      $fb = $firebase(new Firebase('Mock://').child('data'));
-      flushAll = flush.bind(null, $fb.$ref());
+      var ref = new Firebase('Mock://').child('data');
+      ref.set(defaults.data);
+      ref.flush();
+      $fb = $firebase(ref);
+      flushAll = flush.bind(null, ref);
     });
 
     it('should return a promise', function() {
@@ -353,7 +366,6 @@ describe('$firebase', function () {
     });
 
     it('should not destroy untouched keys', function() {
-      flushAll();
       var data = $fb.$ref().getData();
       data.a = 'foo';
       delete data.b;
@@ -373,7 +385,6 @@ describe('$firebase', function () {
 
     it('should work on a query object', function() {
       var $fb2 = $firebase($fb.$ref().limit(1));
-      flushAll();
       $fb2.$update({foo: 'bar'});
       flushAll();
       expect($fb2.$ref().ref().getData().foo).toBe('bar');
@@ -445,7 +456,10 @@ describe('$firebase', function () {
 
     beforeEach(function() {
       $ArrayFactory = stubArrayFactory();
-      $fb = $firebase(new Firebase('Mock://').child('data'), {arrayFactory: $ArrayFactory});
+      var ref = new Firebase('Mock://').child('data');
+      ref.set(defaults.data);
+      ref.flush();
+      $fb = $firebase(ref, {arrayFactory: $ArrayFactory});
     });
 
     it('should call $FirebaseArray constructor with correct args', function() {
@@ -580,10 +594,9 @@ describe('$firebase', function () {
 
     it('should call $$error if an error event occurs', function() {
       var arr = $fb.$asArray();
-      // flush all the existing data through
       flushAll();
       $fb.$ref().forceCancel('test_failure');
-      flushAll();
+      $timeout.flush();
       expect(arr.$$error).toHaveBeenCalledWith('test_failure');
     });
 
@@ -642,7 +655,10 @@ describe('$firebase', function () {
 
     beforeEach(function() {
       var Factory = stubObjectFactory();
-      $fb = $firebase(new Firebase('Mock://').child('data'), {objectFactory: Factory});
+      var ref = new Firebase('Mock://').child('data');
+      ref.set(defaults.data);
+      ref.flush();
+      $fb = $firebase(ref, {objectFactory: Factory});
       $fb.$Factory = Factory;
     });
 
@@ -689,7 +705,7 @@ describe('$firebase', function () {
       flushAll();
       expect(obj.$$error).not.toHaveBeenCalled();
       ref.forceCancel('test_cancel');
-      flushAll();
+      $timeout.flush();
       expect(obj.$$error).toHaveBeenCalledWith('test_cancel');
     });
 


### PR DESCRIPTION
MF 0.6 replicates Angular behavior with respect to flushing its deferred queue
When ref#flush is called with no deferred events an exception is thrown

MF 0.7 removes default data. I set up its old defaults as a fixture here.
