### PR TITLE
Only run SauceLabs on git tags

### DIFF
--- a/tests/travis.sh
+++ b/tests/travis.sh
@@ -1,6 +1,5 @@
 grunt build
 grunt test:unit
-#if [ $SAUCE_ACCESS_KEY ]; then
-  #grunt sauce:unit
-  #grunt sauce:e2e
-#fi
+if [ $TRAVIS_TAG ]; then
+  grunt sauce:unit;
+fi


### PR DESCRIPTION
@katowulf - As per [this discussion](https://github.com/firebase/angularfire/pull/493#issuecomment-65463170), we will now only run SauceLabs tests upon git tags. Thanks for the code snippet @bendrucker!
