### PR TITLE
Added $changeEmail() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ In order to use AngularFire in your project, you need to include the following f
 
 ```html
 <!-- AngularJS -->
-<script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.3.7/angular.min.js"></script>
+<script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.3.8/angular.min.js"></script>
 
 <!-- Firebase -->
 <script src="https://cdn.firebase.com/js/client/2.1.0/firebase.js"></script>

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ In order to use AngularFire in your project, you need to include the following f
 <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.3.7/angular.min.js"></script>
 
 <!-- Firebase -->
-<script src="https://cdn.firebase.com/js/client/2.0.6/firebase.js"></script>
+<script src="https://cdn.firebase.com/js/client/2.1.0/firebase.js"></script>
 
 <!-- AngularFire -->
 <script src="https://cdn.firebase.com/libs/angularfire/0.9.0/angularfire.min.js"></script>

--- a/bower.json
+++ b/bower.json
@@ -31,7 +31,7 @@
   ],
   "dependencies": {
     "angular": "1.2.x || 1.3.x",
-    "firebase": "2.0.x"
+    "firebase": "2.1.x"
   },
   "devDependencies": {
     "lodash": "~2.4.1",

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,2 +1,3 @@
+feature - Added `$firebaseAuth.$changeEmail()` to change the email address associated with an existing account.
 deprecated - Passing in credentials to the user management methods of `$firebaseAuth` as individual arguments has been deprecated in favor of a single credentials argument.
 deprecated - Deprecated `$firebaseAuth.$sendPasswordResetEmail()` in favor of the functionally equivalent `$firebaseAuth.$resetPassword()`.

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   ],
   "dependencies": {
     "angular": "1.3.x",
-    "firebase": "2.0.x"
+    "firebase": "2.1.x"
   },
   "devDependencies": {
     "coveralls": "^2.11.1",

--- a/src/FirebaseAuth.js
+++ b/src/FirebaseAuth.js
@@ -51,6 +51,7 @@
         // User management methods
         $createUser: this.createUser.bind(this),
         $changePassword: this.changePassword.bind(this),
+        $changeEmail: this.changeEmail.bind(this),
         $removeUser: this.removeUser.bind(this),
         $resetPassword: this.resetPassword.bind(this),
         $sendPasswordResetEmail: this.sendPasswordResetEmail.bind(this)
@@ -303,7 +304,7 @@
      * Changes the password for an email/password user.
      *
      * @param {Object|string} emailOrCredentials The email of the user whose password is to change
-     * or an objet containing the email, old password, and new password of the user whose password
+     * or an object containing the email, old password, and new password of the user whose password
      * is to change.
      * @param {string} [oldPassword] The current password for the user.
      * @param {string} [newPassword] The new password for the user.
@@ -325,6 +326,21 @@
       }
 
       this._ref.changePassword(credentials, this._utils.makeNodeResolver(deferred));
+
+      return deferred.promise;
+    },
+
+    /**
+     * Changes the email for an email/password user.
+     *
+     * @param {Object} credentials An object containing the old email, new email, and password of
+     * the user whose email is to change.
+     * @return {Promise<>} An empty promise fulfilled once the email change is complete.
+     */
+    changeEmail: function(credentials) {
+      var deferred = this._q.defer();
+
+      this._ref.changeEmail(credentials, this._utils.makeNodeResolver(deferred));
 
       return deferred.promise;
     },

--- a/src/FirebaseAuth.js
+++ b/src/FirebaseAuth.js
@@ -340,7 +340,11 @@
     changeEmail: function(credentials) {
       var deferred = this._q.defer();
 
-      this._ref.changeEmail(credentials, this._utils.makeNodeResolver(deferred));
+      try {
+        this._ref.changeEmail(credentials, this._utils.makeNodeResolver(deferred));
+      } catch (error) {
+        deferred.reject(error);
+      }
 
       return deferred.promise;
     },

--- a/src/FirebaseAuth.js
+++ b/src/FirebaseAuth.js
@@ -338,16 +338,16 @@
      * @return {Promise<>} An empty promise fulfilled once the email change is complete.
      */
     changeEmail: function(credentials) {
+      if (typeof this._ref.changeEmail !== 'function') {
+        throw new Error('$firebaseAuth.$changeEmail() requires Firebase version 2.1.0 or greater.');
+      }
+
       var deferred = this._q.defer();
 
-      if (typeof this._ref.changeEmail !== 'function') {
-        deferred.reject('$firebaseAuth.$changeEmail() requires Firebase version 2.1.0 or greater.');
-      } else {
-        try {
-          this._ref.changeEmail(credentials, this._utils.makeNodeResolver(deferred));
-        } catch (error) {
-          deferred.reject(error);
-        }
+      try {
+        this._ref.changeEmail(credentials, this._utils.makeNodeResolver(deferred));
+      } catch (error) {
+        deferred.reject(error);
       }
 
       return deferred.promise;

--- a/src/FirebaseAuth.js
+++ b/src/FirebaseAuth.js
@@ -340,10 +340,14 @@
     changeEmail: function(credentials) {
       var deferred = this._q.defer();
 
-      try {
-        this._ref.changeEmail(credentials, this._utils.makeNodeResolver(deferred));
-      } catch (error) {
-        deferred.reject(error);
+      if (typeof this._ref.changeEmail !== 'function') {
+        deferred.reject('$firebaseAuth.$changeEmail() requires Firebase version 2.1.0 or greater.');
+      } else {
+        try {
+          this._ref.changeEmail(credentials, this._utils.makeNodeResolver(deferred));
+        } catch (error) {
+          deferred.reject(error);
+        }
       }
 
       return deferred.promise;

--- a/tests/unit/FirebaseAuth.spec.js
+++ b/tests/unit/FirebaseAuth.spec.js
@@ -27,7 +27,7 @@ describe('FirebaseAuth',function(){
       ['authWithCustomToken','authAnonymously','authWithPassword',
         'authWithOAuthPopup','authWithOAuthRedirect','authWithOAuthToken',
         'unauth','getAuth','onAuth','offAuth',
-        'createUser','changePassword','removeUser','resetPassword'
+        'createUser','changePassword','changeEmail','removeUser','resetPassword'
       ]);
 
     inject(function(_$firebaseAuth_,_$timeout_){
@@ -197,7 +197,7 @@ describe('FirebaseAuth',function(){
       expect(result).toEqual('myResult');
     });
   });
-  
+
   describe('$authWithOAuthToken',function(){
     it('passes provider, token, and options object to underlying method',function(){
       var provider = 'facebook';
@@ -361,42 +361,95 @@ describe('FirebaseAuth',function(){
       expect(result).toEqual({uid:'1234'});
     });
   });
-  
-  describe('$changePassword()',function(){
-    it('passes email/password to method on backing ref (string args)',function(){
+
+  describe('$changePassword()',function() {
+    it('passes credentials to method on backing ref (string args)',function() {
       auth.$changePassword('somebody@somewhere.com','54321','12345');
-      expect(ref.changePassword).toHaveBeenCalledWith(
-        {email:'somebody@somewhere.com',oldPassword:'54321',newPassword:'12345'},
-        jasmine.any(Function));
+      expect(ref.changePassword).toHaveBeenCalledWith({
+        email: 'somebody@somewhere.com',
+        oldPassword: '54321',
+        newPassword: '12345'
+      }, jasmine.any(Function));
     });
 
-    it('passes email/password to method on backing ref (object arg)',function(){
-      auth.$changePassword({email:'somebody@somewhere.com',oldPassword:'54321',newPassword:'12345'});
-      expect(ref.changePassword).toHaveBeenCalledWith(
-        {email:'somebody@somewhere.com',oldPassword:'54321',newPassword:'12345'},
-        jasmine.any(Function));
+    it('passes credentials to method on backing ref (object arg)',function() {
+      auth.$changePassword({
+        email: 'somebody@somewhere.com',
+        oldPassword: '54321',
+        newPassword: '12345'
+      });
+      expect(ref.changePassword).toHaveBeenCalledWith({
+        email:'somebody@somewhere.com',
+        oldPassword: '54321',
+        newPassword: '12345'
+      }, jasmine.any(Function));
     });
 
-    it('will log a warning if deprecated string args are used',function(){
+    it('will log a warning if deprecated string args are used',function() {
       auth.$changePassword('somebody@somewhere.com','54321','12345');
       expect(log.warn).toHaveLength(1);
     });
 
-    it('will reject the promise if authentication fails',function(){
-      wrapPromise(auth.$changePassword({email:'somebody@somewhere.com',oldPassword:'54321',newPassword:'12345'}));
+    it('will reject the promise if authentication fails',function() {
+      wrapPromise(auth.$changePassword({
+        email:'somebody@somewhere.com',
+        oldPassword: '54321',
+        newPassword: '12345'
+      }));
       callback('changePassword')("bad password");
       $timeout.flush();
       expect(failure).toEqual("bad password");
     });
 
-    it('will resolve the promise upon authentication',function(){
-      wrapPromise(auth.$changePassword('somebody@somewhere.com','54321','12345'));
+    it('will resolve the promise upon authentication',function() {
+      wrapPromise(auth.$changePassword({
+        email: 'somebody@somewhere.com',
+        oldPassword: '54321',
+        newPassword: '12345'
+      }));
       callback('changePassword')(null);
       $timeout.flush();
       expect(status).toEqual('resolved');
     });
   });
-  
+
+  describe('$changeEmail()',function() {
+    it('passes credentials to method on backing reference', function() {
+      auth.$changeEmail({
+        oldEmail: 'somebody@somewhere.com',
+        newEmail: 'otherperson@somewhere.com',
+        password: '12345'
+      });
+      expect(ref.changeEmail).toHaveBeenCalledWith({
+        oldEmail: 'somebody@somewhere.com',
+        newEmail: 'otherperson@somewhere.com',
+        password: '12345'
+      }, jasmine.any(Function));
+    });
+
+    it('will reject the promise if authentication fails',function() {
+      wrapPromise(auth.$changeEmail({
+        oldEmail: 'somebody@somewhere.com',
+        newEmail: 'otherperson@somewhere.com',
+        password: '12345'
+      }));
+      callback('changeEmail')("bad password");
+      $timeout.flush();
+      expect(failure).toEqual("bad password");
+    });
+
+    it('will resolve the promise upon authentication',function() {
+      wrapPromise(auth.$changeEmail({
+        oldEmail: 'somebody@somewhere.com',
+        newEmail: 'otherperson@somewhere.com',
+        password: '12345'
+      }));
+      callback('changeEmail')(null);
+      $timeout.flush();
+      expect(status).toEqual('resolved');
+    });
+  });
+
   describe('$removeUser()',function(){
     it('passes email/password to method on backing ref (string args)',function(){
       auth.$removeUser('somebody@somewhere.com','12345');
@@ -431,7 +484,7 @@ describe('FirebaseAuth',function(){
       expect(status).toEqual('resolved');
     });
   });
-  
+
   describe('$sendPasswordResetEmail()',function(){
     it('passes email to method on backing ref (string args)',function(){
       auth.$sendPasswordResetEmail('somebody@somewhere.com');
@@ -451,7 +504,7 @@ describe('FirebaseAuth',function(){
       auth.$sendPasswordResetEmail({email:'somebody@somewhere.com'});
       expect(log.warn).toHaveLength(1);
     });
-    
+
     it('will log two deprecation warnings if string arg is used',function(){
       auth.$sendPasswordResetEmail('somebody@somewhere.com');
       expect(log.warn).toHaveLength(2);
@@ -471,7 +524,7 @@ describe('FirebaseAuth',function(){
       expect(status).toEqual('resolved');
     });
   });
-  
+
   describe('$resetPassword()',function(){
     it('passes email to method on backing ref (string args)',function(){
       auth.$resetPassword('somebody@somewhere.com');

--- a/tests/unit/FirebaseAuth.spec.js
+++ b/tests/unit/FirebaseAuth.spec.js
@@ -401,7 +401,7 @@ describe('FirebaseAuth',function(){
       expect(failure).toEqual("bad password");
     });
 
-    it('will resolve the promise upon authentication',function() {
+    it('will resolve the promise upon the password change',function() {
       wrapPromise(auth.$changePassword({
         email: 'somebody@somewhere.com',
         oldPassword: '54321',
@@ -438,7 +438,7 @@ describe('FirebaseAuth',function(){
       expect(failure).toEqual("bad password");
     });
 
-    it('will resolve the promise upon authentication',function() {
+    it('will resolve the promise upon the email change',function() {
       wrapPromise(auth.$changeEmail({
         oldEmail: 'somebody@somewhere.com',
         newEmail: 'otherperson@somewhere.com',

--- a/tests/unit/FirebaseAuth.spec.js
+++ b/tests/unit/FirebaseAuth.spec.js
@@ -390,7 +390,7 @@ describe('FirebaseAuth',function(){
       expect(log.warn).toHaveLength(1);
     });
 
-    it('will reject the promise if authentication fails',function() {
+    it('will reject the promise if the password change fails',function() {
       wrapPromise(auth.$changePassword({
         email:'somebody@somewhere.com',
         oldPassword: '54321',
@@ -427,7 +427,7 @@ describe('FirebaseAuth',function(){
       }, jasmine.any(Function));
     });
 
-    it('will reject the promise if authentication fails',function() {
+    it('will reject the promise if the email change fails',function() {
       wrapPromise(auth.$changeEmail({
         oldEmail: 'somebody@somewhere.com',
         newEmail: 'otherperson@somewhere.com',


### PR DESCRIPTION
@katowulf - Please review but **do not merge yet!.** Wait until the JS client release goes out which adds `changeEmail()`, then merge this guy in before releasing 0.9.1. I am assuming the Firebase version will be 2.1.0, but please update the README in this PR if that version turns out to be 2.0.7.