### PR TITLE
Simplify MockFirebase.override call for mock setup

### DIFF
--- a/tests/mocks/mocks.firebase.js
+++ b/tests/mocks/mocks.firebase.js
@@ -1,5 +1,1 @@
-
-angular.module('mock.firebase', [])
-  .run(function($window) {
-    $window.MockFirebase.override();
-  });
+MockFirebase.override();

--- a/tests/unit/FirebaseArray.spec.js
+++ b/tests/unit/FirebaseArray.spec.js
@@ -30,7 +30,6 @@ describe('$FirebaseArray', function () {
 
   var $firebase, $fb, $fbOldTodo, arr, $FirebaseArray, $utils, $rootScope, $timeout, destroySpy, testutils;
   beforeEach(function() {
-    module('mock.firebase');
     module('firebase');
     module('testutils');
     inject(function ($firebase, _$FirebaseArray_, $firebaseUtils, _$rootScope_, _$timeout_, _testutils_) {

--- a/tests/unit/FirebaseAuth.spec.js
+++ b/tests/unit/FirebaseAuth.spec.js
@@ -9,7 +9,6 @@ describe('FirebaseAuth',function(){
       warn:[]
     };
 
-    module('mock.firebase');
     module('firebase',function($provide){
       $provide.value('$log',{
         warn:function(){

--- a/tests/unit/FirebaseObject.spec.js
+++ b/tests/unit/FirebaseObject.spec.js
@@ -11,7 +11,6 @@ describe('$FirebaseObject', function() {
   };
 
   beforeEach(function () {
-    module('mock.firebase');
     module('firebase');
     module('testutils');
     inject(function (_$firebase_, _$interval_, _$FirebaseObject_, _$timeout_, $firebaseUtils, _$rootScope_, _testutils_) {

--- a/tests/unit/firebase.spec.js
+++ b/tests/unit/firebase.spec.js
@@ -7,7 +7,6 @@ describe('$firebase', function () {
 
   beforeEach(function() {
     module('firebase');
-    module('mock.firebase');
     module('mock.utils');
     // have to create these before the first call to inject
     // or they will not be registered with the angular mock injector

--- a/tests/unit/utils.spec.js
+++ b/tests/unit/utils.spec.js
@@ -2,7 +2,6 @@
 describe('$firebaseUtils', function () {
   var $utils, $timeout, testutils;
   beforeEach(function () {
-    module('mock.firebase');
     module('firebase');
     module('testutils');
     inject(function (_$firebaseUtils_, _$timeout_, _testutils_) {


### PR DESCRIPTION
Related to katowulf/mockfirebase#50

There's no need to declare a module with a run block and then call `angular.mock.module` to invoke it. The fact that `mocks/**/*.js` comes before the unit test files means that `window.MockFirebase.override` will have been called just by including a simple script file that calls it. 