### PR TITLE
remove redundant call to `ref.ref()`

### DIFF
--- a/src/firebase.js
+++ b/src/firebase.js
@@ -52,7 +52,7 @@
             }
             if( angular.isFunction(ref.set) || !angular.isObject(data) ) {
               // this is not a query, just do a flat set
-              ref.ref().set(data, this._handle(def, ref));
+              ref.set(data, this._handle(def, ref));
             }
             else {
               var dataCopy = angular.extend({}, data);


### PR DESCRIPTION
in this case there has already been a check that `set()` exists and is a function