### PR TITLE
fix: travis.sh should exit with an error if any of the build steps fail.

### DIFF
--- a/tests/travis.sh
+++ b/tests/travis.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+set -e
 grunt build
 grunt test:unit
 if [ $TRAVIS_TAG ]; then


### PR DESCRIPTION
Closes #542.
This was accomplished by adding the `set -e` flag documented
[here](http://stackoverflow.com/questions/2870992/automatic-exit-from-bash-shell-script-on-error).