### PR TITLE
Bindto performance enhancement and fixes.

### DIFF
--- a/src/FirebaseObject.js
+++ b/src/FirebaseObject.js
@@ -324,23 +324,20 @@
                 scopeValue.$value === rec.$value;
             }
 
-            function getScope() {
-              return $firebaseUtils.scopeData(parsed(scope));
-            }
-
             function setScope(rec) {
               parsed.assign(scope, $firebaseUtils.scopeData(rec));
             }
 
-            var send = $firebaseUtils.debounce(function() {
-              rec.$$scopeUpdated(getScope())
+            var send = $firebaseUtils.debounce(function(val) {
+              rec.$$scopeUpdated($firebaseUtils.scopeData(val))
                 ['finally'](function() { sending = false; });
             }, 50, 500);
 
             var scopeUpdated = function(newVal) {
-              if( !equals(newVal[0]) ) {
+              newVal = newVal[0];
+              if( !equals(newVal) ) {
                 sending = true;
-                send();
+                send(newVal);
               }
             };
 

--- a/src/FirebaseObject.js
+++ b/src/FirebaseObject.js
@@ -318,12 +318,10 @@
             self.scope = scope;
             self.varName = varName;
 
-            function equals(rec) {
-              var parsed = getScope();
-              var newData = $firebaseUtils.scopeData(rec);
-              return angular.equals(parsed, newData) &&
-                parsed.$priority === rec.$priority &&
-                parsed.$value === rec.$value;
+            function equals(scopeValue) {
+              return angular.equals(scopeValue, rec) &&
+                scopeValue.$priority === rec.$priority &&
+                scopeValue.$value === rec.$value;
             }
 
             function getScope() {
@@ -339,15 +337,15 @@
                 ['finally'](function() { sending = false; });
             }, 50, 500);
 
-            var scopeUpdated = function() {
-              if( !equals(rec) ) {
+            var scopeUpdated = function(newVal) {
+              if( !equals(newVal[0]) ) {
                 sending = true;
                 send();
               }
             };
 
             var recUpdated = function() {
-              if( !sending && !equals(rec) ) {
+              if( !sending && !equals(parsed(scope)) ) {
                 setScope(rec);
               }
             };

--- a/src/FirebaseObject.js
+++ b/src/FirebaseObject.js
@@ -354,20 +354,16 @@
 
             // $watch will not check any vars prefixed with $, so we
             // manually check $priority and $value using this method
-            function checkMetaVars() {
-              var dat = parsed(scope);
-              if( dat.$value !== rec.$value || dat.$priority !== rec.$priority ) {
-                scopeUpdated();
-              }
+            function watchExp(){
+              var obj = parsed(scope);
+              return [obj, obj.$priority, obj.$value];
             }
-
-            self.subs.push(scope.$watch(checkMetaVars));
 
             setScope(rec);
             self.subs.push(scope.$on('$destroy', self.unbind.bind(self)));
 
             // monitor scope for any changes
-            self.subs.push(scope.$watch(varName, scopeUpdated, true));
+            self.subs.push(scope.$watch(watchExp, scopeUpdated, true));
 
             // monitor the object for changes
             self.subs.push(rec.$watch(recUpdated));


### PR DESCRIPTION
Optimizes bindTo performance and fixes potential for listener function to be called twice.

The individual commit messages contain a decent amount of detail, so check those for further info.

It seems to make the e2e tests run far more reliably to me (including fixing the TicTacToe test that used to fail for me 100% of the time). They still timeout occasionally (far less frequently), so this is a step in the right direction on #512.