### PR TITLE
Added error message when trying to use array-like data stored in Firebase

### DIFF
--- a/src/FirebaseArray.js
+++ b/src/FirebaseArray.js
@@ -210,6 +210,8 @@
         $loaded: function(resolve, reject) {
           var promise = this._promise;
           if( arguments.length ) {
+            // allow this method to be called just like .then
+            // by passing any arguments on to .then
             promise = promise.then.call(promise, resolve, reject);
           }
           return promise;

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -202,7 +202,13 @@
             ref.on('child_removed', removed, error);
 
             // determine when initial load is completed
-            ref.once('value', function() { resolve(null); }, resolve);
+            ref.once('value', function(snap) {
+              if (angular.isArray(snap.val())) {
+                throw new Error('Storing data using array indices in Firebase can result in unexpected behavior. See https://www.firebase.com/docs/rest/guide/understanding-data.html#section-arrays-in-firebase for more information.');
+              }
+
+              resolve(null);
+            }, resolve);
           }
 
           // call resolve(), do not call this directly
@@ -281,7 +287,13 @@
 
           function init() {
             ref.on('value', applyUpdate, error);
-            ref.once('value', function() { resolve(null); }, resolve);
+            ref.once('value', function(snap) {
+              if (angular.isArray(snap.val())) {
+                throw new Error('Storing data using array indices in Firebase can result in unexpected behavior. See https://www.firebase.com/docs/rest/guide/understanding-data.html#section-arrays-in-firebase for more information.');
+              }
+
+              resolve(null);
+            }, resolve);
           }
 
           // call resolve(); do not call this directly

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -9,8 +9,8 @@
     //
     //   * `ref`: A Firebase reference. Queries or limits may be applied.
     //   * `config`: An object containing any of the advanced config options explained in API docs
-    .factory("$firebase", [ "$firebaseUtils", "$firebaseConfig",
-      function ($firebaseUtils, $firebaseConfig) {
+    .factory("$firebase", [ "$log", "$firebaseUtils", "$firebaseConfig",
+      function ($log, $firebaseUtils, $firebaseConfig) {
         function AngularFire(ref, config) {
           // make the new keyword optional
           if (!(this instanceof AngularFire)) {
@@ -204,7 +204,7 @@
             // determine when initial load is completed
             ref.once('value', function(snap) {
               if (angular.isArray(snap.val())) {
-                throw new Error('Storing data using array indices in Firebase can result in unexpected behavior. See https://www.firebase.com/docs/rest/guide/understanding-data.html#section-arrays-in-firebase for more information.');
+                $log.warn('Storing data using array indices in Firebase can result in unexpected behavior. See https://www.firebase.com/docs/web/guide/understanding-data.html#section-arrays-in-firebase for more information.');
               }
 
               resolve(null);
@@ -289,7 +289,7 @@
             ref.on('value', applyUpdate, error);
             ref.once('value', function(snap) {
               if (angular.isArray(snap.val())) {
-                throw new Error('Storing data using array indices in Firebase can result in unexpected behavior. See https://www.firebase.com/docs/rest/guide/understanding-data.html#section-arrays-in-firebase for more information.');
+                $log.warn('Storing data using array indices in Firebase can result in unexpected behavior. See https://www.firebase.com/docs/web/guide/understanding-data.html#section-arrays-in-firebase for more information.');
               }
 
               resolve(null);


### PR DESCRIPTION
@katowulf - This fixes #534. I chose to throw a synchronous error and still allow the binding to work. But hopefully this should be enough of an indication that they are not following best practices and should update their data structure. I'm open to changes in wording in the error message. As for performance impact on this, we are doing an extra `val()` call now, which could theoretically hurt us. The data will already be cached locally though (and we do a `val()` elsewhere), so the impact should be minimal.