### PR TITLE
Added API access for AngularFire version number

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -432,6 +432,12 @@
             });
             return dat;
           },
+
+          /**
+           * AngularFire version number.
+           */
+          VERSION: '0.0.0',
+
           batchDelay: firebaseBatchDelay,
           allPromises: $q.all.bind($q)
         };

--- a/tests/unit/utils.spec.js
+++ b/tests/unit/utils.spec.js
@@ -237,7 +237,7 @@ describe('$firebaseUtils', function () {
       callback(false);
       expect(deferred.reject).toHaveBeenCalledWith(false);
     });
-    
+
     it('should resolve the promise if the first argument is null', function(){
       var result = {data:'hello world'};
       callback(null,result);
@@ -252,6 +252,11 @@ describe('$firebaseUtils', function () {
     });
   });
 
+  describe('#VERSION', function() {
+    it('should return the version number', function() {
+      expect($utils.VERSION).toEqual('0.0.0');
+    });
+  });
 });
 
 describe('#promise (ES6 Polyfill)', function(){


### PR DESCRIPTION
@katowulf - Implements #516. I chose to put this in `$firebaseUtils` for two reasons:

  1. `$firebase` is going away, so it doesn't make sense to put it there.
  2. I don't really want this to be used very much, so putting it the undocumented `$firebaseUtils` will keep it nicely hidden from most users eyes.

Note that Catapult will dynamically replace `0.0.0` with the correct version number at release time.