### PR TITLE
Worked around issue with Jasmine's new array equality check

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "grunt-notify": "^0.4.1",
     "grunt-protractor-runner": "^1.2.1",
     "grunt-shell-spawn": "^0.3.1",
-    "jasmine-core": "^2.1.3",
+    "jasmine-core": "^2.2.0",
     "jasmine-spec-reporter": "^2.1.0",
     "karma": "~0.12.31",
     "karma-chrome-launcher": "^0.1.7",

--- a/tests/unit/FirebaseArray.spec.js
+++ b/tests/unit/FirebaseArray.spec.js
@@ -486,7 +486,10 @@ describe('$FirebaseArray', function () {
       expect(len).toBeGreaterThan(0);
       var copy = testutils.deepCopyObject(arr);
       arr.$$updated(testutils.snap('foo', 'notarealkey'));
-      expect(arr).toEqual(copy);
+      expect(len).toEqual(copy.length);
+      for (var i = 0; i < len; i++) {
+        expect(arr[i]).toEqual(copy[i]);
+      }
     });
 
     it('should preserve ids', function() {


### PR DESCRIPTION
`jasmine-core` 2.2.0 ([changlog here](Check custom properties on Arrays when computing equality)) changed the equality check for arrays which appears to break one of our tests:

> Check custom properties on Arrays when computing equality

This change works around that issue by looping through the array and checking for each item's equality.

Fixes issue #552.