### PR TITLE
Rename $FirebaseArray and $FirebaseObject

### DIFF
--- a/src/FirebaseObject.js
+++ b/src/FirebaseObject.js
@@ -14,7 +14,7 @@
    * method to add or change how methods behave:
    *
    * <pre><code>
-   * var ExtendedObject = $FirebaseObject.$extend({
+   * var ExtendedObject = $firebaseObject.$extend({
    *    // add a new method to the prototype
    *    foo: function() { return 'bar'; },
    * });
@@ -22,7 +22,7 @@
    * var obj = new ExtendedObject(ref);
    * </code></pre>
    */
-  angular.module('firebase').factory('$FirebaseObject', [
+  angular.module('firebase').factory('$firebaseObject', [
     '$parse', '$firebaseUtils', '$log',
     function($parse, $firebaseUtils, $log) {
       /**
@@ -33,6 +33,9 @@
        * @constructor
        */
       function FirebaseObject(ref) {
+        if( !(this instanceof FirebaseObject) ) {
+          return new FirebaseObject(ref);
+        }
         // These are private config props and functions used internally
         // they are collected here to reduce clutter in console.log and forEach
         this.$$conf = {
@@ -266,14 +269,14 @@
        * `objectFactory` parameter:
        *
        * <pre><code>
-       * var MyFactory = $FirebaseObject.$extend({
+       * var MyFactory = $firebaseObject.$extend({
        *    // add a method onto the prototype that prints a greeting
        *    getGreeting: function() {
        *       return 'Hello ' + this.first_name + ' ' + this.last_name + '!';
        *    }
        * });
        *
-       * // use our new factory in place of $FirebaseObject
+       * // use our new factory in place of $firebaseObject
        * var obj = $firebase(ref, {objectFactory: MyFactory}).$asObject();
        * </code></pre>
        *
@@ -412,7 +415,7 @@
           ref.on('value', applyUpdate, error);
           ref.once('value', function(snap) {
             if (angular.isArray(snap.val())) {
-              $log.warn('Storing data using array indices in Firebase can result in unexpected behavior. See https://www.firebase.com/docs/web/guide/understanding-data.html#section-arrays-in-firebase for more information. Also note that you probably wanted $FirebaseArray and not $FirebaseObject.');
+              $log.warn('Storing data using array indices in Firebase can result in unexpected behavior. See https://www.firebase.com/docs/web/guide/understanding-data.html#section-arrays-in-firebase for more information. Also note that you probably wanted $firebaseArray and not $firebaseObject.');
             }
 
             initComplete(null);
@@ -452,6 +455,16 @@
       }
 
       return FirebaseObject;
+    }
+  ]);
+
+  /** @deprecated */
+  angular.module('firebase').factory('$FirebaseObject', ['$log', '$firebaseObject',
+    function($log, $firebaseObject) {
+      return function() {
+        $log.warn('$FirebaseObject has been renamed. Use $firebaseObject instead.');
+        return $firebaseObject.apply(null, arguments);
+      };
     }
   ]);
 })();

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -6,7 +6,7 @@
     /** @deprecated */
     .factory("$firebase", function() {
       return function() {
-        throw new Error('$firebase has been removed. You may instantiate $FirebaseArray and $FirebaseObject ' +
+        throw new Error('$firebase has been removed. You may instantiate $firebaseArray and $firebaseObject ' +
         'directly now. For simple write operations, just use the Firebase ref directly. ' +
         'See the AngularFire 1.0.0 changelog for details: https://www.firebase.com/docs/web/libraries/angular/changelog.html');
       };

--- a/src/utils.js
+++ b/src/utils.js
@@ -2,8 +2,8 @@
   'use strict';
 
   angular.module('firebase')
-    .factory('$firebaseConfig', ["$FirebaseArray", "$FirebaseObject", "$injector",
-      function($FirebaseArray, $FirebaseObject, $injector) {
+    .factory('$firebaseConfig', ["$firebaseArray", "$firebaseObject", "$injector",
+      function($firebaseArray, $firebaseObject, $injector) {
         return function(configOpts) {
           // make a copy we can modify
           var opts = angular.extend({}, configOpts);
@@ -16,8 +16,8 @@
           }
           // extend defaults and return
           return angular.extend({
-            arrayFactory: $FirebaseArray,
-            objectFactory: $FirebaseObject
+            arrayFactory: $firebaseArray,
+            objectFactory: $firebaseObject
           }, opts);
         };
       }

--- a/tests/protractor/chat/chat.js
+++ b/tests/protractor/chat/chat.js
@@ -1,20 +1,18 @@
 var app = angular.module('chat', ['firebase']);
-app.controller('ChatCtrl', function Chat($scope, $FirebaseObject, $FirebaseArray) {
+app.controller('ChatCtrl', function Chat($scope, $firebaseObject, $firebaseArray) {
   // Get a reference to the Firebase
   var chatFirebaseRef = new Firebase('https://angularFireTests.firebaseio-demo.com/chat');
   var messagesFirebaseRef = chatFirebaseRef.child("messages").limitToLast(2);
 
-  // Get AngularFire sync objects
-
   // Get the chat data as an object
-  $scope.chat = new $FirebaseObject(chatFirebaseRef);
+  $scope.chat = $firebaseObject(chatFirebaseRef);
 
   // Get the chat messages as an array
-  $scope.messages = new $FirebaseArray(messagesFirebaseRef);
+  $scope.messages = $firebaseArray(messagesFirebaseRef);
 
   // Verify that $inst() works
-  verify($scope.chat.$ref() === chatFirebaseRef, "Something is wrong with $FirebaseObject.$inst().");
-  verify($scope.messages.$ref() === messagesFirebaseRef, "Something is wrong with $FirebaseArray.$inst().");
+  verify($scope.chat.$ref() === chatFirebaseRef, "Something is wrong with $firebaseObject.$ref().");
+  verify($scope.messages.$ref() === messagesFirebaseRef, "Something is wrong with $firebaseArray.$ref().");
 
   // Initialize $scope variables
   $scope.message = "";

--- a/tests/protractor/priority/priority.js
+++ b/tests/protractor/priority/priority.js
@@ -1,13 +1,13 @@
 var app = angular.module('priority', ['firebase']);
-app.controller('PriorityCtrl', function Chat($scope, $FirebaseArray, $FirebaseObject) {
+app.controller('PriorityCtrl', function Chat($scope, $firebaseArray, $firebaseObject) {
   // Get a reference to the Firebase
   var messagesFirebaseRef = new Firebase('https://angularFireTests.firebaseio-demo.com/priority');
 
   // Get the chat messages as an array
-  $scope.messages = new $FirebaseArray(messagesFirebaseRef);
+  $scope.messages = $firebaseArray(messagesFirebaseRef);
 
   // Verify that $inst() works
-  verify($scope.messages.$ref() === messagesFirebaseRef, 'Something is wrong with $FirebaseArray.$ref().');
+  verify($scope.messages.$ref() === messagesFirebaseRef, 'Something is wrong with $firebaseArray.$ref().');
 
   // Initialize $scope variables
   $scope.message = '';
@@ -27,17 +27,17 @@ app.controller('PriorityCtrl', function Chat($scope, $FirebaseArray, $FirebaseOb
         from: $scope.username,
         content: $scope.message
       }).then(function (ref) {
-        var newItem = new $FirebaseObject(ref);
+        var newItem = $firebaseObject(ref);
 
         newItem.$loaded().then(function (data) {
-          verify(newItem === data, '$FirebaseObject.$loaded() does not return correct value.');
+          verify(newItem === data, '$firebaseObject.$loaded() does not return correct value.');
 
           // Update the message's priority
           newItem.$priority = priority;
           newItem.$save();
         });
       }, function (error) {
-        verify(false, 'Something is wrong with $FirebaseArray.$add().');
+        verify(false, 'Something is wrong with $firebaseArray.$add().');
       });
 
       // Reset the message input

--- a/tests/protractor/tictactoe/tictactoe.js
+++ b/tests/protractor/tictactoe/tictactoe.js
@@ -1,16 +1,16 @@
 var app = angular.module('tictactoe', ['firebase']);
-app.controller('TicTacToeCtrl', function Chat($scope, $FirebaseObject) {
+app.controller('TicTacToeCtrl', function Chat($scope, $firebaseObject) {
   // Get a reference to the Firebase
   var boardFirebaseRef = new Firebase('https://angularFireTests.firebaseio-demo.com/tictactoe');
 
   // Get the board as an AngularFire object
-  $scope.boardObject = new $FirebaseObject(boardFirebaseRef);
+  $scope.boardObject = $firebaseObject(boardFirebaseRef);
 
   // Create a 3-way binding to Firebase
   $scope.boardObject.$bindTo($scope, 'board');
 
   // Verify that $inst() works
-  verify($scope.boardObject.$ref() === boardFirebaseRef, 'Something is wrong with $FirebaseObject.$ref().');
+  verify($scope.boardObject.$ref() === boardFirebaseRef, 'Something is wrong with $firebaseObject.$ref().');
 
   // Initialize $scope variables
   $scope.whoseTurn = 'X';

--- a/tests/protractor/todo/todo.js
+++ b/tests/protractor/todo/todo.js
@@ -1,13 +1,13 @@
 var app = angular.module('todo', ['firebase']);
-app. controller('TodoCtrl', function Todo($scope, $FirebaseArray) {
+app. controller('TodoCtrl', function Todo($scope, $firebaseArray) {
   // Get a reference to the Firebase
   var todosFirebaseRef = new Firebase('https://angularFireTests.firebaseio-demo.com/todo');
 
   // Get the todos as an array
-  $scope.todos = new $FirebaseArray(todosFirebaseRef);
+  $scope.todos = $firebaseArray(todosFirebaseRef);
 
   // Verify that $ref() works
-  verify($scope.todos.$ref() === todosFirebaseRef, "Something is wrong with $FirebaseArray.$ref().");
+  verify($scope.todos.$ref() === todosFirebaseRef, "Something is wrong with $firebaseArray.$ref().");
 
   /* Clears the todos Firebase reference */
   $scope.clearRef = function () {
@@ -35,7 +35,7 @@ app. controller('TodoCtrl', function Todo($scope, $FirebaseArray) {
   /* Removes the todo item with the inputted ID */
   $scope.removeTodo = function(id) {
     // Verify that $indexFor() and $keyAt() work
-    verify($scope.todos.$indexFor($scope.todos.$keyAt(id)) === id, "Something is wrong with $FirebaseArray.$indexFor() or FirebaseArray.$keyAt().");
+    verify($scope.todos.$indexFor($scope.todos.$keyAt(id)) === id, "Something is wrong with $firebaseArray.$indexFor() or FirebaseArray.$keyAt().");
 
     $scope.todos.$remove(id);
   };

--- a/tests/unit/FirebaseArray.spec.js
+++ b/tests/unit/FirebaseArray.spec.js
@@ -1,5 +1,5 @@
 'use strict';
-describe('$FirebaseArray', function () {
+describe('$firebaseArray', function () {
 
   var STUB_DATA = {
     'a': {
@@ -28,14 +28,14 @@ describe('$FirebaseArray', function () {
     }
   };
 
-  var arr, $FirebaseArray, $utils, $timeout, testutils;
+  var arr, $firebaseArray, $utils, $timeout, testutils;
   beforeEach(function() {
     module('firebase');
     module('testutils');
-    inject(function (_$FirebaseArray_, $firebaseUtils, _$timeout_, _testutils_) {
+    inject(function (_$firebaseArray_, $firebaseUtils, _$timeout_, _testutils_) {
       testutils = _testutils_;
       $timeout = _$timeout_;
-      $FirebaseArray = _$FirebaseArray_;
+      $firebaseArray = _$firebaseArray_;
       $utils = $firebaseUtils;
       arr = stubArray(STUB_DATA);
     });
@@ -43,9 +43,9 @@ describe('$FirebaseArray', function () {
 
   describe('<constructor>', function() {
     beforeEach(function() {
-      inject(function($firebaseUtils, $FirebaseArray) {
+      inject(function($firebaseUtils, $firebaseArray) {
         this.$utils = $firebaseUtils;
-        this.$FirebaseArray = $FirebaseArray;
+        this.$firebaseArray = $firebaseArray;
       });
     });
 
@@ -55,7 +55,7 @@ describe('$FirebaseArray', function () {
 
     it('should have API methods', function() {
       var i = 0;
-      this.$utils.getPublicMethods($FirebaseArray, function(v,k) {
+      this.$utils.getPublicMethods($firebaseArray, function(v,k) {
         expect(typeof arr[k]).toBe('function');
         i++;
       });
@@ -139,7 +139,7 @@ describe('$FirebaseArray', function () {
     it('should work on a query', function() {
       var ref = stubRef();
       var query = ref.limit(2);
-      var arr = new $FirebaseArray(query);
+      var arr = $firebaseArray(query);
       addAndProcess(arr, testutils.snap('one', 'b', 1), null);
       expect(arr.length).toBe(1);
     });
@@ -241,7 +241,7 @@ describe('$FirebaseArray', function () {
       ref.set(STUB_DATA);
       ref.flush();
       var query = ref.limit(5);
-      var arr = new $FirebaseArray(query);
+      var arr = $firebaseArray(query);
       flushAll(arr.$ref());
       var key = arr.$keyAt(1);
       arr[1].foo = 'watchtest';
@@ -316,7 +316,7 @@ describe('$FirebaseArray', function () {
         console.error(e);
       });
       var query = ref.limit(5); //todo-mock MockFirebase does not support 2.x queries yet
-      var arr = new $FirebaseArray(query);
+      var arr = $firebaseArray(query);
       flushAll(arr.$ref());
       var key = arr.$keyAt(1);
       arr.$remove(1).then(whiteSpy, blackSpy);
@@ -399,7 +399,7 @@ describe('$FirebaseArray', function () {
       var err = new Error('test_fail');
       var ref = stubRef();
       ref.failNext('on', err);
-      var arr = new $FirebaseArray(ref);
+      var arr = $firebaseArray(ref);
       arr.$loaded().then(whiteSpy, blackSpy);
       flushAll(ref);
       expect(whiteSpy).not.toHaveBeenCalled();
@@ -419,7 +419,7 @@ describe('$FirebaseArray', function () {
       var ref = stubRef();
       var err = new Error('test_fail');
       ref.failNext('once', err);
-      var arr = new $FirebaseArray(ref);
+      var arr = $firebaseArray(ref);
       arr.$loaded(whiteSpy, blackSpy);
       flushAll(ref);
       expect(whiteSpy).not.toHaveBeenCalled();
@@ -430,7 +430,7 @@ describe('$FirebaseArray', function () {
   describe('$ref', function() {
     it('should return Firebase instance it was created with', function() {
       var ref = stubRef();
-      var arr = new $FirebaseArray(ref);
+      var arr = $firebaseArray(ref);
       expect(arr.$ref()).toBe(ref);
     });
   });
@@ -509,7 +509,7 @@ describe('$FirebaseArray', function () {
     });
 
     it('should apply $$defaults if they exist', function() {
-      var arr = stubArray(null, $FirebaseArray.$extend({
+      var arr = stubArray(null, $firebaseArray.$extend({
         $$defaults: {aString: 'not_applied', foo: 'foo'}
       }));
       var res = arr.$$added(testutils.snap(STUB_DATA.a));
@@ -563,7 +563,7 @@ describe('$FirebaseArray', function () {
     });
 
     it('should apply $$defaults if they exist', function() {
-      var arr = stubArray(STUB_DATA, $FirebaseArray.$extend({
+      var arr = stubArray(STUB_DATA, $firebaseArray.$extend({
         $$defaults: {aString: 'not_applied', foo: 'foo'}
       }));
       var rec = arr.$getRecord('a');
@@ -611,7 +611,7 @@ describe('$FirebaseArray', function () {
   describe('$$error', function() {
     it('should call $destroy', function() {
       var spy = jasmine.createSpy('$destroy');
-      var arr = stubArray(STUB_DATA, $FirebaseArray.$extend({ $destroy: spy }));
+      var arr = stubArray(STUB_DATA, $firebaseArray.$extend({ $destroy: spy }));
       spy.calls.reset();
       arr.$$error('test_err');
       expect(spy).toHaveBeenCalled();
@@ -670,7 +670,7 @@ describe('$FirebaseArray', function () {
 
     it('should invoke $$notify with "child_added" event', function() {
       var spy = jasmine.createSpy('$$notify');
-      var arr = stubArray(STUB_DATA, $FirebaseArray.$extend({ $$notify: spy }));
+      var arr = stubArray(STUB_DATA, $firebaseArray.$extend({ $$notify: spy }));
       spy.calls.reset();
       var rec = arr.$$added(testutils.snap({hello: 'world'}, 'addFirst'), null);
       arr.$$process('child_added', rec, null);
@@ -679,7 +679,7 @@ describe('$FirebaseArray', function () {
 
     it('"child_added" should not invoke $$notify if it already exists after prevChild', function() {
       var spy = jasmine.createSpy('$$notify');
-      var arr = stubArray(STUB_DATA, $FirebaseArray.$extend({ $$notify: spy }));
+      var arr = stubArray(STUB_DATA, $firebaseArray.$extend({ $$notify: spy }));
       var index = arr.$indexFor('e');
       var prevChild = arr.$$getKey(arr[index -1]);
       spy.calls.reset();
@@ -691,7 +691,7 @@ describe('$FirebaseArray', function () {
 
     it('should invoke $$notify with "child_changed" event', function() {
       var spy = jasmine.createSpy('$$notify');
-      var arr = stubArray(STUB_DATA, $FirebaseArray.$extend({ $$notify: spy }));
+      var arr = stubArray(STUB_DATA, $firebaseArray.$extend({ $$notify: spy }));
       spy.calls.reset();
       arr.$$updated(testutils.snap({hello: 'world'}, 'a'));
       arr.$$process('child_changed', arr.$getRecord('a'));
@@ -726,7 +726,7 @@ describe('$FirebaseArray', function () {
 
     it('should invoke $$notify with "child_moved" event', function() {
       var spy = jasmine.createSpy('$$notify');
-      var arr = stubArray(STUB_DATA, $FirebaseArray.$extend({ $$notify: spy }));
+      var arr = stubArray(STUB_DATA, $firebaseArray.$extend({ $$notify: spy }));
       spy.calls.reset();
       arr.$$moved(testutils.refSnap(testutils.ref('b')), 'notarealkey');
       arr.$$process('child_moved', arr.$getRecord('b'), 'notarealkey');
@@ -735,7 +735,7 @@ describe('$FirebaseArray', function () {
 
     it('"child_moved" should not trigger $$notify if prevChild is already the previous element' , function() {
       var spy = jasmine.createSpy('$$notify');
-      var arr = stubArray(STUB_DATA, $FirebaseArray.$extend({ $$notify: spy }));
+      var arr = stubArray(STUB_DATA, $firebaseArray.$extend({ $$notify: spy }));
       var index = arr.$indexFor('e');
       var prevChild = arr.$$getKey(arr[index - 1]);
       spy.calls.reset();
@@ -755,7 +755,7 @@ describe('$FirebaseArray', function () {
 
     it('should trigger $$notify with "child_removed" event', function() {
       var spy = jasmine.createSpy('$$notify');
-      var arr = stubArray(STUB_DATA, $FirebaseArray.$extend({ $$notify: spy }));
+      var arr = stubArray(STUB_DATA, $firebaseArray.$extend({ $$notify: spy }));
       spy.calls.reset();
       arr.$$removed(testutils.refSnap(testutils.ref('e')));
       arr.$$process('child_removed', arr.$getRecord('e'));
@@ -764,7 +764,7 @@ describe('$FirebaseArray', function () {
 
     it('"child_removed" should not trigger $$notify if the record is not in the array' , function() {
       var spy = jasmine.createSpy('$$notify');
-      var arr = stubArray(STUB_DATA, $FirebaseArray.$extend({ $$notify: spy }));
+      var arr = stubArray(STUB_DATA, $firebaseArray.$extend({ $$notify: spy }));
       spy.calls.reset();
       arr.$$process('child_removed', {$id:'f'});
       expect(spy).not.toHaveBeenCalled();
@@ -782,33 +782,33 @@ describe('$FirebaseArray', function () {
 
   describe('$extend', function() {
     it('should return a valid array', function() {
-      var F = $FirebaseArray.$extend({});
+      var F = $firebaseArray.$extend({});
       expect(Array.isArray(new F(stubRef()))).toBe(true);
     });
 
     it('should preserve child prototype', function() {
-      function Extend() { $FirebaseArray.apply(this, arguments); }
+      function Extend() { $firebaseArray.apply(this, arguments); }
       Extend.prototype.foo = function() {};
-      $FirebaseArray.$extend(Extend);
+      $firebaseArray.$extend(Extend);
       var arr = new Extend(stubRef());
       expect(typeof(arr.foo)).toBe('function');
     });
 
     it('should return child class', function() {
       function A() {}
-      var res = $FirebaseArray.$extend(A);
+      var res = $firebaseArray.$extend(A);
       expect(res).toBe(A);
     });
 
-    it('should be instanceof $FirebaseArray', function() {
+    it('should be instanceof $firebaseArray', function() {
       function A() {}
-      $FirebaseArray.$extend(A);
-      expect(new A(stubRef()) instanceof $FirebaseArray).toBe(true);
+      $firebaseArray.$extend(A);
+      expect(new A(stubRef()) instanceof $firebaseArray).toBe(true);
     });
 
     it('should add on methods passed into function', function() {
       function foo() { return 'foo'; }
-      var F = $FirebaseArray.$extend({foo: foo});
+      var F = $firebaseArray.$extend({foo: foo});
       var res = new F(stubRef());
       expect(typeof res.$$updated).toBe('function');
       expect(typeof res.foo).toBe('function');
@@ -832,7 +832,7 @@ describe('$FirebaseArray', function () {
   }
 
   function stubArray(initialData, Factory, ref) {
-    if( !Factory ) { Factory = $FirebaseArray; }
+    if( !Factory ) { Factory = $firebaseArray; }
     if( !ref ) {
       ref = stubRef();
     }

--- a/tests/unit/FirebaseObject.spec.js
+++ b/tests/unit/FirebaseObject.spec.js
@@ -1,6 +1,6 @@
-describe('$FirebaseObject', function() {
+describe('$firebaseObject', function() {
   'use strict';
-  var $FirebaseObject, $utils, $rootScope, $timeout, obj, testutils, $interval, log;
+  var $firebaseObject, $utils, $rootScope, $timeout, obj, testutils, $interval, log;
 
   var DEFAULT_ID = 'REC1';
   var FIXTURE_DATA = {
@@ -23,8 +23,8 @@ describe('$FirebaseObject', function() {
         }
       })
     });
-    inject(function (_$interval_, _$FirebaseObject_, _$timeout_, $firebaseUtils, _$rootScope_, _testutils_) {
-      $FirebaseObject = _$FirebaseObject_;
+    inject(function (_$interval_, _$firebaseObject_, _$timeout_, $firebaseUtils, _$rootScope_, _testutils_) {
+      $firebaseObject = _$firebaseObject_;
       $timeout = _$timeout_;
       $interval = _$interval_;
       $utils = $firebaseUtils;
@@ -49,7 +49,7 @@ describe('$FirebaseObject', function() {
     });
 
     it('should apply $$defaults if they exist', function() {
-      var F = $FirebaseObject.$extend({
+      var F = $firebaseObject.$extend({
         $$defaults: {aNum: 0, aStr: 'foo', aBool: false}
       });
       var ref = stubRef();
@@ -108,7 +108,7 @@ describe('$FirebaseObject', function() {
       ref.flush();
       var spy = spyOn(ref, 'update');
       var query = ref.limit(3);
-      var obj = new $FirebaseObject(query);
+      var obj = $firebaseObject(query);
       flushAll(query);
       obj.foo = 'bar';
       obj.$save();
@@ -207,7 +207,7 @@ describe('$FirebaseObject', function() {
   describe('$ref', function () {
     it('should return the Firebase instance that created it', function () {
       var ref = stubRef();
-      var obj = new $FirebaseObject(ref);
+      var obj = $firebaseObject(ref);
       expect(obj.$ref()).toBe(ref);
     });
   });
@@ -376,7 +376,7 @@ describe('$FirebaseObject', function() {
     it('should update $value if $value changed in $scope', function () {
       var $scope = $rootScope.$new();
       var ref = stubRef();
-      var obj = new $FirebaseObject(ref);
+      var obj = $firebaseObject(ref);
       ref.flush();
       obj.$$updated(testutils.refSnap(ref, 'foo', null));
       expect(obj.$value).toBe('foo');
@@ -396,7 +396,7 @@ describe('$FirebaseObject', function() {
       var ref = stubRef();
       ref.autoFlush(true);
       ref.setWithPriority({text:'hello'},3);
-      var obj = new $FirebaseObject(ref);
+      var obj = $firebaseObject(ref);
       flushAll();
       flushAll();
       obj.$bindTo($scope, 'test');
@@ -518,7 +518,7 @@ describe('$FirebaseObject', function() {
       ref.set({foo: 'bar'});
       ref.flush();
       var query = ref.limit(3);
-      var obj = new $FirebaseObject(query);
+      var obj = $firebaseObject(query);
       flushAll(query);
       expect(obj.foo).toBe('bar');
       obj.$remove();
@@ -561,32 +561,32 @@ describe('$FirebaseObject', function() {
   describe('$extend', function () {
     it('should preserve child prototype', function () {
       function Extend() {
-        $FirebaseObject.apply(this, arguments);
+        $firebaseObject.apply(this, arguments);
       }
       Extend.prototype.foo = function () {};
       var ref = stubRef();
-      $FirebaseObject.$extend(Extend);
+      $firebaseObject.$extend(Extend);
       var arr = new Extend(ref);
       expect(arr.foo).toBeA('function');
     });
 
     it('should return child class', function () {
       function A() {}
-      var res = $FirebaseObject.$extend(A);
+      var res = $firebaseObject.$extend(A);
       expect(res).toBe(A);
     });
 
-    it('should be instanceof $FirebaseObject', function () {
+    it('should be instanceof $firebaseObject', function () {
       function A() {}
-      $FirebaseObject.$extend(A);
-      expect(new A(stubRef())).toBeInstanceOf($FirebaseObject);
+      $firebaseObject.$extend(A);
+      expect(new A(stubRef())).toBeInstanceOf($firebaseObject);
     });
 
     it('should add on methods passed into function', function () {
       function foo() {
         return 'foo';
       }
-      var F = $FirebaseObject.$extend({foo: foo});
+      var F = $firebaseObject.$extend({foo: foo});
       var res = new F(stubRef());
       expect(res.$$updated).toBeA('function');
       expect(res.foo).toBeA('function');
@@ -640,7 +640,7 @@ describe('$FirebaseObject', function() {
     });
 
     it('should apply $$defaults if they exist', function() {
-      var F = $FirebaseObject.$extend({
+      var F = $firebaseObject.$extend({
         $$defaults: {baz: 'baz', aString: 'bravo'}
       });
       var obj = new F(stubRef());
@@ -690,7 +690,7 @@ describe('$FirebaseObject', function() {
     if( !ref ) {
       ref = stubRef();
     }
-    var obj = new $FirebaseObject(ref);
+    var obj = $firebaseObject(ref);
     if (angular.isDefined(initialData)) {
       ref.ref().set(initialData);
       ref.flush();


### PR DESCRIPTION
@jwngr a quickie but goodie

Fixes #559 - rename $FirebaseArray and $FirebaseObject to lower case first case letter
Fixes #558 - make new keyword optional

FirebaseArray.js:
 - renamed $FirebaseArray to $firebaseArray
 - made new keyword optional
 - cleaned up comments at top
 - added warning/redirect for $FirebaseArray service

FirebaseObject.js
 - renamed $FirebaseObject to $firebaseObject
 - made new keyword optional
 - added warning/redirect for $FirebaseObject service

test/* refactor for above changes
test/chat.js: replaced $inst with $ref in a message