### PR TITLE
Removed deprecated auth methods and functionality

### DIFF
--- a/src/FirebaseAuth.js
+++ b/src/FirebaseAuth.js
@@ -311,7 +311,7 @@
 
       // Throw an error if they are trying to pass in separate string arguments
       if (typeof credentials === "string") {
-        throw new Error("Passing in credentials to $createUser() as individual arguments has been removed in favor of a single credentials argument. See the AngularFire API reference for details.");
+        throw new Error("$createUser() expects an object containing 'email' and 'password', but got a string.");
       }
 
       try {
@@ -335,7 +335,7 @@
 
       // Throw an error if they are trying to pass in separate string arguments
       if (typeof credentials === "string") {
-        throw new Error("Passing in credentials to $changePassword() as individual arguments has been removed in favor of a single credentials argument. See the AngularFire API reference for details.");
+        throw new Error("$changePassword() expects an object containing 'email', 'oldPassword', and 'newPassword', but got a string.");
       }
 
       try {
@@ -356,7 +356,7 @@
      */
     changeEmail: function(credentials) {
       if (typeof this._ref.changeEmail !== 'function') {
-        throw new Error('$firebaseAuth.$changeEmail() requires Firebase version 2.1.0 or greater.');
+        throw new Error("$changeEmail() expects an object containing 'oldEmail', 'newEmail', and 'password', but got a string.");
       }
 
       var deferred = this._q.defer();
@@ -381,7 +381,7 @@
 
       // Throw an error if they are trying to pass in separate string arguments
       if (typeof credentials === "string") {
-        throw new Error("Passing in credentials to $removeUser() as individual arguments has been removed in favor of a single credentials argument. See the AngularFire API reference for details.");
+        throw new Error("$removeUser() expects an object containing 'email' and 'password', but got a string.");
       }
 
       try {
@@ -406,7 +406,7 @@
 
       // Throw an error if they are trying to pass in a string argument
       if (typeof credentials === "string") {
-        throw new Error("Passing in credentials to $resetPassword() as individual arguments has been removed in favor of a single credentials argument. See the AngularFire API reference for details.");
+        throw new Error("$resetPassword() expects an object containing 'email', but got a string.");
       }
 
       try {

--- a/src/FirebaseAuth.js
+++ b/src/FirebaseAuth.js
@@ -53,8 +53,7 @@
         $changePassword: this.changePassword.bind(this),
         $changeEmail: this.changeEmail.bind(this),
         $removeUser: this.removeUser.bind(this),
-        $resetPassword: this.resetPassword.bind(this),
-        $sendPasswordResetEmail: this.sendPasswordResetEmail.bind(this)
+        $resetPassword: this.resetPassword.bind(this)
       };
 
       return this._object;
@@ -303,24 +302,16 @@
      * wish to log in as the newly created user, call $authWithPassword() after the promise for
      * this method has been resolved.
      *
-     * @param {Object|string} emailOrCredentials The email of the user to create or an object
-     * containing the email and password of the user to create.
-     * @param {string} [password] The password for the user to create.
+     * @param {Object} credentials An object containing the email and password of the user to create.
      * @return {Promise<Object>} A promise fulfilled with the user object, which contains the
      * uid of the created user.
      */
-    createUser: function(emailOrCredentials, password) {
+    createUser: function(credentials) {
       var deferred = this._q.defer();
 
-      // Allow this method to take a single credentials argument or two separate string arguments
-      var credentials = emailOrCredentials;
-      if (typeof emailOrCredentials === "string") {
-        this._log.warn("Passing in credentials to $createUser() as individual arguments has been deprecated in favor of a single credentials argument. See the AngularFire API reference for details.");
-
-        credentials = {
-          email: emailOrCredentials,
-          password: password
-        };
+      // Throw an error if they are trying to pass in separate string arguments
+      if (typeof credentials === "string") {
+        throw new Error("Passing in credentials to $createUser() as individual arguments has been removed in favor of a single credentials argument. See the AngularFire API reference for details.");
       }
 
       try {
@@ -335,26 +326,16 @@
     /**
      * Changes the password for an email/password user.
      *
-     * @param {Object|string} emailOrCredentials The email of the user whose password is to change
-     * or an object containing the email, old password, and new password of the user whose password
-     * is to change.
-     * @param {string} [oldPassword] The current password for the user.
-     * @param {string} [newPassword] The new password for the user.
+     * @param {Object} credentials An object containing the email, old password, and new password of
+     * the user whose password is to change.
      * @return {Promise<>} An empty promise fulfilled once the password change is complete.
      */
-    changePassword: function(emailOrCredentials, oldPassword, newPassword) {
+    changePassword: function(credentials) {
       var deferred = this._q.defer();
 
-      // Allow this method to take a single credentials argument or three separate string arguments
-      var credentials = emailOrCredentials;
-      if (typeof emailOrCredentials === "string") {
-        this._log.warn("Passing in credentials to $changePassword() as individual arguments has been deprecated in favor of a single credentials argument. See the AngularFire API reference for details.");
-
-        credentials = {
-          email: emailOrCredentials,
-          oldPassword: oldPassword,
-          newPassword: newPassword
-        };
+      // Throw an error if they are trying to pass in separate string arguments
+      if (typeof credentials === "string") {
+        throw new Error("Passing in credentials to $changePassword() as individual arguments has been removed in favor of a single credentials argument. See the AngularFire API reference for details.");
       }
 
       try {
@@ -392,23 +373,15 @@
     /**
      * Removes an email/password user.
      *
-     * @param {Object|string} emailOrCredentials The email of the user to remove or an object
-     * containing the email and password of the user to remove.
-     * @param {string} [password] The password of the user to remove.
+     * @param {Object} credentials An object containing the email and password of the user to remove.
      * @return {Promise<>} An empty promise fulfilled once the user is removed.
      */
-    removeUser: function(emailOrCredentials, password) {
+    removeUser: function(credentials) {
       var deferred = this._q.defer();
 
-      // Allow this method to take a single credentials argument or two separate string arguments
-      var credentials = emailOrCredentials;
-      if (typeof emailOrCredentials === "string") {
-        this._log.warn("Passing in credentials to $removeUser() as individual arguments has been deprecated in favor of a single credentials argument. See the AngularFire API reference for details.");
-
-        credentials = {
-          email: emailOrCredentials,
-          password: password
-        };
+      // Throw an error if they are trying to pass in separate string arguments
+      if (typeof credentials === "string") {
+        throw new Error("Passing in credentials to $removeUser() as individual arguments has been removed in favor of a single credentials argument. See the AngularFire API reference for details.");
       }
 
       try {
@@ -420,44 +393,20 @@
       return deferred.promise;
     },
 
-    /**
-     * Sends a password reset email to an email/password user. [DEPRECATED]
-     *
-     * @deprecated
-     * @param {Object|string} emailOrCredentials The email of the user to send a reset password
-     * email to or an object containing the email of the user to send a reset password email to.
-     * @return {Promise<>} An empty promise fulfilled once the reset password email is sent.
-     */
-    sendPasswordResetEmail: function(emailOrCredentials) {
-      this._log.warn("$sendPasswordResetEmail() has been deprecated in favor of the equivalent $resetPassword().");
-
-      try {
-        return this.resetPassword(emailOrCredentials);
-      } catch (error) {
-        return this._q(function(resolve, reject) {
-          return reject(error);
-        });
-      }
-    },
 
     /**
      * Sends a password reset email to an email/password user.
      *
-     * @param {Object|string} emailOrCredentials The email of the user to send a reset password
-     * email to or an object containing the email of the user to send a reset password email to.
+     * @param {Object} credentials An object containing the email of the user to send a reset
+     * password email to.
      * @return {Promise<>} An empty promise fulfilled once the reset password email is sent.
      */
-    resetPassword: function(emailOrCredentials) {
+    resetPassword: function(credentials) {
       var deferred = this._q.defer();
 
-      // Allow this method to take a single credentials argument or a single string argument
-      var credentials = emailOrCredentials;
-      if (typeof emailOrCredentials === "string") {
-        this._log.warn("Passing in credentials to $resetPassword() as individual arguments has been deprecated in favor of a single credentials argument. See the AngularFire API reference for details.");
-
-        credentials = {
-          email: emailOrCredentials
-        };
+      // Throw an error if they are trying to pass in a string argument
+      if (typeof credentials === "string") {
+        throw new Error("Passing in credentials to $resetPassword() as individual arguments has been removed in favor of a single credentials argument. See the AngularFire API reference for details.");
       }
 
       try {

--- a/tests/unit/FirebaseAuth.spec.js
+++ b/tests/unit/FirebaseAuth.spec.js
@@ -320,23 +320,17 @@ describe('FirebaseAuth',function(){
   });
 
   describe('$createUser()',function(){
-    it('passes email/password to method on backing ref (string args)',function(){
-      auth.$createUser('somebody@somewhere.com','12345');
-      expect(ref.createUser).toHaveBeenCalledWith(
-        {email:'somebody@somewhere.com',password:'12345'},
-        jasmine.any(Function));
-    });
-
-    it('will log a warning if deprecated string arguments are used',function(){
-      auth.$createUser('somebody@somewhere.com','12345');
-      expect(log.warn).toHaveLength(1);
-    });
-
-    it('passes email/password to method on backing ref (object arg)',function(){
+    it('passes email/password to method on backing ref',function(){
       auth.$createUser({email:'somebody@somewhere.com',password:'12345'});
       expect(ref.createUser).toHaveBeenCalledWith(
           {email:'somebody@somewhere.com',password:'12345'},
           jasmine.any(Function));
+    });
+
+    it('throws error given string arguments',function(){
+      expect(function() {
+        auth.$createUser('somebody@somewhere.com', '12345');
+      }).toThrow();
     });
 
     it('will reject the promise if creation fails',function(){
@@ -362,16 +356,7 @@ describe('FirebaseAuth',function(){
   });
 
   describe('$changePassword()',function() {
-    it('passes credentials to method on backing ref (string args)',function() {
-      auth.$changePassword('somebody@somewhere.com','54321','12345');
-      expect(ref.changePassword).toHaveBeenCalledWith({
-        email: 'somebody@somewhere.com',
-        oldPassword: '54321',
-        newPassword: '12345'
-      }, jasmine.any(Function));
-    });
-
-    it('passes credentials to method on backing ref (object arg)',function() {
+    it('passes credentials to method on backing ref',function() {
       auth.$changePassword({
         email: 'somebody@somewhere.com',
         oldPassword: '54321',
@@ -384,9 +369,10 @@ describe('FirebaseAuth',function(){
       }, jasmine.any(Function));
     });
 
-    it('will log a warning if deprecated string args are used',function() {
-      auth.$changePassword('somebody@somewhere.com','54321','12345');
-      expect(log.warn).toHaveLength(1);
+    it('throws error given string arguments',function(){
+      expect(function() {
+        auth.$changePassword('somebody@somewhere.com', '54321', '12345');
+      }).toThrow();
     });
 
     it('will reject the promise if the password change fails',function() {
@@ -450,23 +436,17 @@ describe('FirebaseAuth',function(){
   });
 
   describe('$removeUser()',function(){
-    it('passes email/password to method on backing ref (string args)',function(){
-      auth.$removeUser('somebody@somewhere.com','12345');
-      expect(ref.removeUser).toHaveBeenCalledWith(
-        {email:'somebody@somewhere.com',password:'12345'},
-        jasmine.any(Function));
-    });
-
-    it('passes email/password to method on backing ref (object arg)',function(){
+    it('passes email/password to method on backing ref',function(){
       auth.$removeUser({email:'somebody@somewhere.com',password:'12345'});
       expect(ref.removeUser).toHaveBeenCalledWith(
         {email:'somebody@somewhere.com',password:'12345'},
         jasmine.any(Function));
     });
 
-    it('will log a warning if deprecated string args are used',function(){
-      auth.$removeUser('somebody@somewhere.com','12345');
-      expect(log.warn).toHaveLength(1);
+    it('throws error given string arguments',function(){
+      expect(function() {
+        auth.$removeUser('somebody@somewhere.com', '12345');
+      }).toThrow();
     });
 
     it('will reject the promise if there is an error',function(){
@@ -484,64 +464,18 @@ describe('FirebaseAuth',function(){
     });
   });
 
-  describe('$sendPasswordResetEmail()',function(){
-    it('passes email to method on backing ref (string args)',function(){
-      auth.$sendPasswordResetEmail('somebody@somewhere.com');
-      expect(ref.resetPassword).toHaveBeenCalledWith(
-        {email:'somebody@somewhere.com'},
-        jasmine.any(Function));
-    });
-
-    it('passes email to method on backing ref (object arg)',function(){
-      auth.$sendPasswordResetEmail({email:'somebody@somewhere.com'});
-      expect(ref.resetPassword).toHaveBeenCalledWith(
-        {email:'somebody@somewhere.com'},
-        jasmine.any(Function));
-    });
-
-    it('will log a deprecation warning (object arg)',function(){
-      auth.$sendPasswordResetEmail({email:'somebody@somewhere.com'});
-      expect(log.warn).toHaveLength(1);
-    });
-
-    it('will log two deprecation warnings if string arg is used',function(){
-      auth.$sendPasswordResetEmail('somebody@somewhere.com');
-      expect(log.warn).toHaveLength(2);
-    });
-
-    it('will reject the promise if reset action fails',function(){
-      wrapPromise(auth.$sendPasswordResetEmail({email:'somebody@somewhere.com'}));
-      callback('resetPassword')("user not found");
-      $timeout.flush();
-      expect(failure).toEqual("user not found");
-    });
-
-    it('will resolve the promise upon success',function(){
-      wrapPromise(auth.$sendPasswordResetEmail({email:'somebody@somewhere.com'}));
-      callback('resetPassword')(null);
-      $timeout.flush();
-      expect(status).toEqual('resolved');
-    });
-  });
-
   describe('$resetPassword()',function(){
-    it('passes email to method on backing ref (string args)',function(){
-      auth.$resetPassword('somebody@somewhere.com');
-      expect(ref.resetPassword).toHaveBeenCalledWith(
-        {email:'somebody@somewhere.com'},
-        jasmine.any(Function));
-    });
-
-    it('passes email to method on backing ref (object arg)',function(){
+    it('passes email to method on backing ref',function(){
       auth.$resetPassword({email:'somebody@somewhere.com'});
       expect(ref.resetPassword).toHaveBeenCalledWith(
         {email:'somebody@somewhere.com'},
         jasmine.any(Function));
     });
 
-    it('will log a warning if deprecated string arg is used',function(){
-      auth.$resetPassword('somebody@somewhere.com');
-      expect(log.warn).toHaveLength(1);
+    it('throws error given string arguments',function(){
+      expect(function() {
+        auth.$resetPassword('somebody@somewhere.com');
+      }).toThrow();
     });
 
     it('will reject the promise if reset action fails',function(){


### PR DESCRIPTION
@katowulf - Since we are going to do a major version bump, we can get rid of some old cruft. This removes all deprecated methods and functionality in our auth stuff. Here is a list of changes:
* The previously deprecated ability to pass in credentials to the user management methods of `$firebaseAuth` as individual arguments has been removed in favor of a single credentials argument. We now throw a helpful error message.
* The previously deprecated `$sendPasswordResetEmail()` method has been removed; use the equivalent `$resetPassword()` method instead.