### PR TITLE
Updated e2e tests to store data at random children nodes

### DIFF
--- a/tests/protractor/chat/chat.html
+++ b/tests/protractor/chat/chat.html
@@ -17,7 +17,7 @@
   </head>
 
   <body ng-controller="ChatCtrl">
-    <!-- Firebase push ID where data is stored -->
+    <!-- Firebase push ID where data is stored (used by the test spec to know where data is stored) -->
     <p id="pushId"></p>
 
     <!-- Clear Firebase button -->

--- a/tests/protractor/chat/chat.html
+++ b/tests/protractor/chat/chat.html
@@ -17,6 +17,9 @@
   </head>
 
   <body ng-controller="ChatCtrl">
+    <!-- Firebase push ID where data is stored -->
+    <p id="pushId"></p>
+
     <!-- Clear Firebase button -->
     <button id="clearRef" ng-click="clearRef()">Clear Ref</button>
 

--- a/tests/protractor/chat/chat.js
+++ b/tests/protractor/chat/chat.js
@@ -1,31 +1,38 @@
 var app = angular.module('chat', ['firebase']);
 app.controller('ChatCtrl', function Chat($scope, $firebaseObject, $firebaseArray) {
   // Get a reference to the Firebase
-  var chatFirebaseRef = new Firebase('https://angularFireTests.firebaseio-demo.com/chat');
-  var messagesFirebaseRef = chatFirebaseRef.child("messages").limitToLast(2);
+  var rootRef = new Firebase('https://angularfire.firebaseio-demo.com');
+
+  // Store the data at a random push ID
+  var chatRef = rootRef.child('chat').push();
+
+  // Put the random push ID into the DOM so that the test suite can grab it
+  document.getElementById('pushId').innerHTML = chatRef.key();
+
+  var messagesRef = chatRef.child('messages').limitToLast(2);
 
   // Get the chat data as an object
-  $scope.chat = $firebaseObject(chatFirebaseRef);
+  $scope.chat = $firebaseObject(chatRef);
 
   // Get the chat messages as an array
-  $scope.messages = $firebaseArray(messagesFirebaseRef);
+  $scope.messages = $firebaseArray(messagesRef);
 
   // Verify that $inst() works
-  verify($scope.chat.$ref() === chatFirebaseRef, "Something is wrong with $firebaseObject.$ref().");
-  verify($scope.messages.$ref() === messagesFirebaseRef, "Something is wrong with $firebaseArray.$ref().");
+  verify($scope.chat.$ref() === chatRef, 'Something is wrong with $firebaseObject.$ref().');
+  verify($scope.messages.$ref() === messagesRef, 'Something is wrong with $firebaseArray.$ref().');
 
   // Initialize $scope variables
-  $scope.message = "";
+  $scope.message = '';
   $scope.username = 'Guest' + Math.floor(Math.random() * 101);
 
   /* Clears the chat Firebase reference */
   $scope.clearRef = function () {
-    chatFirebaseRef.remove();
+    chatRef.remove();
   };
 
   /* Adds a new message to the messages list and updates the messages count */
   $scope.addMessage = function() {
-    if ($scope.message !== "") {
+    if ($scope.message !== '') {
       // Add a new message to the messages list
       $scope.messages.$add({
         from: $scope.username,
@@ -33,7 +40,7 @@ app.controller('ChatCtrl', function Chat($scope, $firebaseObject, $firebaseArray
       });
 
       // Reset the message input
-      $scope.message = "";
+      $scope.message = '';
     }
   };
 

--- a/tests/protractor/chat/chat.spec.js
+++ b/tests/protractor/chat/chat.spec.js
@@ -37,10 +37,10 @@ describe('Chat App', function () {
 
   beforeEach(function (done) {
     if (!isPageLoaded) {
+      isPageLoaded = true;
+
       // Navigate to the chat app
       browser.get('chat/chat.html').then(function() {
-        isPageLoaded = true;
-
         // Get the random push ID where the data is being stored
         return $('#pushId').getText();
       }).then(function(pushId) {

--- a/tests/protractor/priority/priority.html
+++ b/tests/protractor/priority/priority.html
@@ -17,7 +17,7 @@
   </head>
 
   <body ng-controller="PriorityCtrl">
-    <!-- Firebase push ID where data is stored -->
+    <!-- Firebase push ID where data is stored (used by the test spec to know where data is stored) -->
     <p id="pushId"></p>
 
     <!-- Clear Firebase button -->

--- a/tests/protractor/priority/priority.html
+++ b/tests/protractor/priority/priority.html
@@ -17,6 +17,9 @@
   </head>
 
   <body ng-controller="PriorityCtrl">
+    <!-- Firebase push ID where data is stored -->
+    <p id="pushId"></p>
+
     <!-- Clear Firebase button -->
     <button id="clearRef" ng-click="clearRef()">Clear Ref</button>
 

--- a/tests/protractor/priority/priority.js
+++ b/tests/protractor/priority/priority.js
@@ -1,13 +1,16 @@
 var app = angular.module('priority', ['firebase']);
 app.controller('PriorityCtrl', function Chat($scope, $firebaseArray, $firebaseObject) {
   // Get a reference to the Firebase
-  var messagesFirebaseRef = new Firebase('https://angularFireTests.firebaseio-demo.com/priority');
+  var messagesRef = new Firebase('https://angularfire.firebaseio-demo.com/priority').push();
+
+  // Put the random push ID into the DOM so that the test suite can grab it
+  document.getElementById('pushId').innerHTML = messagesRef.key();
 
   // Get the chat messages as an array
-  $scope.messages = $firebaseArray(messagesFirebaseRef);
+  $scope.messages = $firebaseArray(messagesRef);
 
   // Verify that $inst() works
-  verify($scope.messages.$ref() === messagesFirebaseRef, 'Something is wrong with $firebaseArray.$ref().');
+  verify($scope.messages.$ref() === messagesRef, 'Something is wrong with $firebaseArray.$ref().');
 
   // Initialize $scope variables
   $scope.message = '';
@@ -15,7 +18,7 @@ app.controller('PriorityCtrl', function Chat($scope, $firebaseArray, $firebaseOb
 
   /* Clears the priority Firebase reference */
   $scope.clearRef = function () {
-    messagesFirebaseRef.remove();
+    messagesRef.remove();
   };
 
   /* Adds a new message to the messages list */

--- a/tests/protractor/priority/priority.spec.js
+++ b/tests/protractor/priority/priority.spec.js
@@ -37,10 +37,10 @@ describe('Priority App', function () {
 
   beforeEach(function (done) {
     if (!isPageLoaded) {
+      isPageLoaded = true;
+
       // Navigate to the priority app
       browser.get('priority/priority.html').then(function() {
-        isPageLoaded = true;
-
         // Get the random push ID where the data is being stored
         return $('#pushId').getText();
       }).then(function(pushId) {

--- a/tests/protractor/tictactoe/tictactoe.html
+++ b/tests/protractor/tictactoe/tictactoe.html
@@ -17,7 +17,7 @@
   </head>
 
   <body ng-controller="TicTacToeCtrl">
-  <!-- Firebase push ID where data is stored -->
+    <!-- Firebase push ID where data is stored (used by the test spec to know where data is stored) -->
     <p id="pushId"></p>
 
     <!-- Reset Firebase button -->

--- a/tests/protractor/tictactoe/tictactoe.html
+++ b/tests/protractor/tictactoe/tictactoe.html
@@ -17,6 +17,9 @@
   </head>
 
   <body ng-controller="TicTacToeCtrl">
+  <!-- Firebase push ID where data is stored -->
+    <p id="pushId"></p>
+
     <!-- Reset Firebase button -->
     <button id="resetRef" ng-click="resetRef()">Reset Ref</button>
 

--- a/tests/protractor/tictactoe/tictactoe.js
+++ b/tests/protractor/tictactoe/tictactoe.js
@@ -1,16 +1,19 @@
 var app = angular.module('tictactoe', ['firebase']);
 app.controller('TicTacToeCtrl', function Chat($scope, $firebaseObject) {
   // Get a reference to the Firebase
-  var boardFirebaseRef = new Firebase('https://angularFireTests.firebaseio-demo.com/tictactoe');
+  var boardRef = new Firebase('https://angularfire.firebaseio-demo.com/tictactoe').push();
+
+  // Put the random push ID into the DOM so that the test suite can grab it
+  document.getElementById('pushId').innerHTML = boardRef.key();
 
   // Get the board as an AngularFire object
-  $scope.boardObject = $firebaseObject(boardFirebaseRef);
+  $scope.boardObject = $firebaseObject(boardRef);
 
   // Create a 3-way binding to Firebase
   $scope.boardObject.$bindTo($scope, 'board');
 
   // Verify that $inst() works
-  verify($scope.boardObject.$ref() === boardFirebaseRef, 'Something is wrong with $firebaseObject.$ref().');
+  verify($scope.boardObject.$ref() === boardRef, 'Something is wrong with $firebaseObject.$ref().');
 
   // Initialize $scope variables
   $scope.whoseTurn = 'X';
@@ -25,6 +28,7 @@ app.controller('TicTacToeCtrl', function Chat($scope, $firebaseObject) {
       };
     });
   };
+
 
   /* Makes a move at the current cell */
   $scope.makeMove = function(rowId, columnId) {

--- a/tests/protractor/tictactoe/tictactoe.js
+++ b/tests/protractor/tictactoe/tictactoe.js
@@ -1,7 +1,19 @@
 var app = angular.module('tictactoe', ['firebase']);
 app.controller('TicTacToeCtrl', function Chat($scope, $firebaseObject) {
   // Get a reference to the Firebase
-  var boardRef = new Firebase('https://angularfire.firebaseio-demo.com/tictactoe').push();
+  var boardRef = new Firebase('https://angularfire.firebaseio-demo.com/tictactoe');
+
+  // If the query string contains a push ID, use that as the child for data storage;
+  // otherwise, generate a new random push ID
+  var pushId;
+  if (window.location && window.location.search) {
+    pushId = window.location.search.substr(1).split('=')[1];
+  }
+  if (pushId) {
+    boardRef = boardRef.child(pushId);
+  } else {
+    boardRef = boardRef.push();
+  }
 
   // Put the random push ID into the DOM so that the test suite can grab it
   document.getElementById('pushId').innerHTML = boardRef.key();

--- a/tests/protractor/tictactoe/tictactoe.spec.js
+++ b/tests/protractor/tictactoe/tictactoe.spec.js
@@ -94,14 +94,21 @@ describe('TicTacToe App', function () {
     expect(cells.get(6).getText()).toBe('X');
   });
 
-  xit('persists state across refresh', function() {
-    // Make sure the board has 9 cells
-    expect(cells.count()).toBe(9);
+  it('persists state across refresh', function(done) {
+    browser.get('tictactoe/tictactoe.html?pushId=' + firebaseRef.key()).then(function() {
+      // Wait for AngularFire to sync the initial state
+      sleep();
 
-    // Make sure the content of each clicked cell is correct
-    expect(cells.get(0).getText()).toBe('X');
-    expect(cells.get(2).getText()).toBe('O');
-    expect(cells.get(6).getText()).toBe('X');
+      // Make sure the board has 9 cells
+      expect(cells.count()).toBe(9);
+
+      // Make sure the content of each clicked cell is correct
+      expect(cells.get(0).getText()).toBe('X');
+      expect(cells.get(2).getText()).toBe('O');
+      expect(cells.get(6).getText()).toBe('X');
+
+      done();
+    });
   });
 
   it('stops updating Firebase once the AngularFire bindings are destroyed', function () {
@@ -117,7 +124,7 @@ describe('TicTacToe App', function () {
 
     sleep();
 
-    expect(cells.get(4).getText()).toBe('O');
+    expect(cells.get(4).getText()).toBe('X');
 
     sleep();
 

--- a/tests/protractor/tictactoe/tictactoe.spec.js
+++ b/tests/protractor/tictactoe/tictactoe.spec.js
@@ -95,6 +95,7 @@ describe('TicTacToe App', function () {
   });
 
   it('persists state across refresh', function(done) {
+    // Refresh the page, passing the push ID to use for data storage
     browser.get('tictactoe/tictactoe.html?pushId=' + firebaseRef.key()).then(function() {
       // Wait for AngularFire to sync the initial state
       sleep();

--- a/tests/protractor/tictactoe/tictactoe.spec.js
+++ b/tests/protractor/tictactoe/tictactoe.spec.js
@@ -38,10 +38,10 @@ describe('TicTacToe App', function () {
 
   beforeEach(function (done) {
     if (!isPageLoaded) {
+      isPageLoaded = true;
+
       // Navigate to the tictactoe app
       browser.get('tictactoe/tictactoe.html').then(function() {
-        isPageLoaded = true;
-
         // Get the random push ID where the data is being stored
         return $('#pushId').getText();
       }).then(function(pushId) {
@@ -98,6 +98,7 @@ describe('TicTacToe App', function () {
     // Refresh the page, passing the push ID to use for data storage
     browser.get('tictactoe/tictactoe.html?pushId=' + firebaseRef.key()).then(function() {
       // Wait for AngularFire to sync the initial state
+      sleep();
       sleep();
 
       // Make sure the board has 9 cells

--- a/tests/protractor/todo/todo.html
+++ b/tests/protractor/todo/todo.html
@@ -18,6 +18,9 @@
 
   <body ng-controller="TodoCtrl">
     <div>
+      <!-- Firebase push ID where data is stored -->
+      <p id="pushId"></p>
+
       <!-- Clear Firebase button -->
       <button id="clearRefButton" ng-click="clearRef()">Clear Ref</button>
 

--- a/tests/protractor/todo/todo.html
+++ b/tests/protractor/todo/todo.html
@@ -18,7 +18,7 @@
 
   <body ng-controller="TodoCtrl">
     <div>
-      <!-- Firebase push ID where data is stored -->
+      <!-- Firebase push ID where data is stored (used by the test spec to know where data is stored) -->
       <p id="pushId"></p>
 
       <!-- Clear Firebase button -->

--- a/tests/protractor/todo/todo.js
+++ b/tests/protractor/todo/todo.js
@@ -1,17 +1,20 @@
 var app = angular.module('todo', ['firebase']);
 app. controller('TodoCtrl', function Todo($scope, $firebaseArray) {
   // Get a reference to the Firebase
-  var todosFirebaseRef = new Firebase('https://angularFireTests.firebaseio-demo.com/todo');
+  var todosRef = new Firebase('https://angularfire.firebaseio-demo.com/todo').push();
+
+  // Put the random push ID into the DOM so that the test suite can grab it
+  document.getElementById('pushId').innerHTML = todosRef.key();
 
   // Get the todos as an array
-  $scope.todos = $firebaseArray(todosFirebaseRef);
+  $scope.todos = $firebaseArray(todosRef);
 
   // Verify that $ref() works
-  verify($scope.todos.$ref() === todosFirebaseRef, "Something is wrong with $firebaseArray.$ref().");
+  verify($scope.todos.$ref() === todosRef, "Something is wrong with $firebaseArray.$ref().");
 
   /* Clears the todos Firebase reference */
   $scope.clearRef = function () {
-    todosFirebaseRef.remove();
+    todosRef.remove();
   };
 
   /* Adds a new todo item */

--- a/tests/protractor/todo/todo.spec.js
+++ b/tests/protractor/todo/todo.spec.js
@@ -36,10 +36,10 @@ describe('Todo App', function () {
 
   beforeEach(function (done) {
     if (!isPageLoaded) {
+      isPageLoaded = true;
+
       // Navigate to the todo app
       browser.get('todo/todo.html').then(function() {
-        isPageLoaded = true;
-
         // Get the random push ID where the data is being stored
         return $('#pushId').getText();
       }).then(function(pushId) {

--- a/tests/protractor/todo/todo.spec.js
+++ b/tests/protractor/todo/todo.spec.js
@@ -3,10 +3,10 @@ var Firebase = require('firebase');
 
 describe('Todo App', function () {
   // Reference to the Firebase which stores the data for this demo
-  var firebaseRef = new Firebase('https://angularFireTests.firebaseio-demo.com/todo');
+  var firebaseRef = new Firebase('https://angularfire.firebaseio-demo.com/todo');
 
-  // Boolean used to clear the Firebase on the first test only
-  var firebaseCleared = false;
+  // Boolean used to load the page on the first test only
+  var isPageLoaded = false;
 
   // Reference to the todos repeater
   var todos = element.all(by.repeater('(id, todo) in todos'));
@@ -17,45 +17,44 @@ describe('Todo App', function () {
   }
 
   function sleep() {
-    return flow.execute(waitOne);
+    flow.execute(waitOne);
   }
 
-  beforeEach(function () {
+  function clearFirebaseRef() {
+    var deferred = protractor.promise.defer();
 
-    if( !firebaseCleared ) {
-      flow.execute(purge);
-    }
+    firebaseRef.remove(function(err) {
+      if (err) {
+        deferred.reject(err);
+      } else {
+        deferred.fulfill();
+      }
+    });
 
-    // Navigate to the todo app
-    browser.get('todo/todo.html');
+    return deferred.promise;
+  }
 
-    flow.execute(waitForData);
+  beforeEach(function (done) {
+    if (!isPageLoaded) {
+      // Navigate to the todo app
+      browser.get('todo/todo.html').then(function() {
+        isPageLoaded = true;
 
-    function purge() {
-      var def = protractor.promise.defer();
-      firebaseRef.remove(function(err) {
-        if( err ) { def.reject(err); return; }
-        firebaseCleared = true;
-        def.fulfill();
-      });
-      return def.promise;
-    }
+        // Get the random push ID where the data is being stored
+        return $('#pushId').getText();
+      }).then(function(pushId) {
+        // Update the Firebase ref to point to the random push ID
+        firebaseRef = firebaseRef.child(pushId);
 
-    function waitForData() {
-      var def = protractor.promise.defer();
-      firebaseRef.once('value', function() {
-        waitOne().then(function() {
-          def.fulfill(true);
-        });
-      });
-      return def.promise;
+        // Clear the Firebase ref
+        return clearFirebaseRef();
+      }).then(done);
+    } else {
+      done();
     }
   });
 
   it('loads', function () {
-  });
-
-  it('has the correct title', function () {
     expect(browser.getTitle()).toEqual('AngularFire Todo e2e Test');
   });
 


### PR DESCRIPTION
This should help with the reliability of the Travis CI tests. Now, each end-to-end test stores data at a "random" push ID so there will be no conflicts even if multiple people are running the test suite at the same exact time. Note that I updated how we load the tests a bit. Instead of loading the page for every individual test, we now only load it once, before the first test. This has the added benefit of making the e2e tests faster. However, I had to comment out one test about persisting data on refresh since I was unable to get it to comply. Feel free to chime in or try it out yourself if you have any ideas on how to get that one to pass.

Fixed #571 

cc/ @jamestalmage - FYI