### PR TITLE
Proposal: Allow extenders of firebaseArray.$$added to return promises.

### DIFF
--- a/src/FirebaseArray.js
+++ b/src/FirebaseArray.js
@@ -628,7 +628,11 @@
         var created = batch(function(snap, prevChild) {
           var rec = firebaseArray.$$added(snap, prevChild);
           if( rec ) {
-            firebaseArray.$$process('child_added', rec, prevChild);
+            $firebaseUtils.resolve(rec).then(function(rec) {
+              if( rec ) {
+                firebaseArray.$$process('child_added', rec, prevChild);
+              }
+            });
           }
         });
         var updated = batch(function(snap) {


### PR DESCRIPTION
This allows you to return promises from $$added like so:

```javascript
var User = $resource('/user/:userId');

var MessagesArray = $firebaseArray.$extend({
  $$added: function(snap, prevChild) {
    var self = this;
    return new Promise(function(resolve, reject) {
      var userId = snap.val().posterId;
      User.get({userId:userId}, function(user) {
        var record = $firebaseArray.$$added.call(self, snap, prevChild);
        record.posterName = user.fullName;
        resolve(record);
      });
    });
  }
});
```

This was just a quick spike. It probably has application beyond just `$$added`, but potential side affects should be thoroughly thought through before spending much more time on it.