### PR TITLE
new-router compatibility (spike - don't merge)

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -86,6 +86,14 @@ module.exports = function(grunt) {
           interrupt : true,
           atBegin: true
         }
+      },
+      example : {
+        files : ['src/**/*.js', 'tests/unit/**/*.spec.js', 'tests/lib/**/*.js', 'tests/mocks/**/*.js', 'router/**/*'],
+        tasks : ['concat'],
+        options : {
+          interrupt : true,
+          atBegin: true
+        }
       }
     },
 
@@ -154,6 +162,8 @@ module.exports = function(grunt) {
   // Sauce tasks
   grunt.registerTask('sauce:unit', ['karma:saucelabs']);
   grunt.registerTask('sauce:e2e', ['concat', 'connect:testserver', 'protractor:saucelabs']);
+
+  grunt.registerTask('example', ['concat', 'connect:testserver', 'watch:example']);
 
   // Watch tests
   grunt.registerTask('test:watch', ['karma:watch']);

--- a/example/new-router/components/edit-message/edit-message.html
+++ b/example/new-router/components/edit-message/edit-message.html
@@ -1,0 +1,7 @@
+<section>
+  <h2>Editing message: {{editMessage.messageId}}</h2>
+  <div>
+    <input type="text" ng-model="editMessage.message.$value">
+  </div>
+  <a ng-link="listMessages">Back to Message List</a>
+</section>

--- a/example/new-router/components/list-messages/list-messages.html
+++ b/example/new-router/components/list-messages/list-messages.html
@@ -1,0 +1,6 @@
+<section>
+  <h1>Messages</h1>
+  <div ng-repeat="messageId in listMessages.messages">
+    <a ng-link="editMessage({messageId:messageId})">{{messageId}}</a>
+  </div>
+</section>

--- a/example/new-router/index.html
+++ b/example/new-router/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head lang="en">
+  <meta charset="UTF-8">
+  <title></title>
+
+  <!-- Angular -->
+  <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.4.0-rc.0/angular.js"></script>
+
+  <!-- Firebase -->
+  <script src="../../bower_components/firebase/firebase.js"></script>
+
+  <!-- AngularFire -->
+  <script src="../../dist/angularfire.js"></script>
+
+  <!-- New Router -->
+  <script src="../../node_modules/angular-new-router/dist/router.es5.js"></script>
+
+  <!-- newRouterFire  -->
+  <script src="../../router/module.js"></script>
+
+  <!-- example app -->
+  <script src="index.js"></script>
+
+</head>
+<body ng-app="example" ng-strict-di ng-controller="AppController">
+
+<div>
+  <ng-viewport></ng-viewport>
+</div>
+</body>
+</html>

--- a/example/new-router/index.js
+++ b/example/new-router/index.js
@@ -1,0 +1,24 @@
+angular.module('example', ['ngNewRouter','firebase','newRouterFire']).
+  controller('AppController', ['$router', AppController]).
+  controller('EditMessageController',  EditMessageController).
+  controller('ListMessagesController', ListMessageController);
+
+function AppController($router) {
+  $router.config([
+    { path: '/', component: 'listMessages'},
+    { path: '/message/:messageId', component: 'editMessage' }
+  ]);
+}
+
+function EditMessageController($routeParams, $firebaseObject){
+  this.messageId = $routeParams.messageId;
+  var ref = new Firebase("https://fbbug.firebaseio.com/messages/" + this.messageId);
+  var sync = $firebaseObject(ref);
+  sync.$bindTo(this, 'message');
+}
+
+EditMessageController.$inject = ['$routeParams', '$firebaseObject'];
+
+function ListMessageController() {
+  this.messages = ['-Jmessage1', '-Jmessage2'];
+}

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "firebase": "2.2.x"
   },
   "devDependencies": {
+    "angular-new-router": "^0.5.3",
     "coveralls": "^2.11.2",
     "grunt": "~0.4.5",
     "grunt-cli": "^0.1.13",

--- a/router/module.js
+++ b/router/module.js
@@ -1,0 +1,31 @@
+angular.module('newRouterFire', ['firebase', 'ngNewRouter'])
+  .value('$resolveScopePromiseStep',resolveScopePromiseStepValue);
+
+angular.module('ngNewRouter')
+  .config(['$pipelineProvider', pipelineDecorator]);
+
+function pipelineDecorator($pipelineProvider) {
+  var i = $pipelineProvider.steps.indexOf('$initControllersStep');
+  $pipelineProvider.steps.splice(i+1,0,'$resolveScopePromiseStep');
+  $pipelineProvider.config($pipelineProvider.steps);
+}
+
+function resolveScopePromiseStepValue(instruction) {
+  return instruction.router.traverseInstruction(instruction, function(instruction) {
+     if (instruction.controller.$$resolveScope) {
+       var oldactivate = instruction.controller.activate;
+       function activate ($injector){
+         this.$$resolveScope(instruction.locals.$scope);
+         if (oldactivate){
+           return $injector.invoke(oldactivate, this, instruction.locals);
+         }
+       }
+       activate.$inject = ['$injector'];
+       instruction.controller.activate = activate;
+       return true;
+     }
+    else {
+       return instruction.controller;
+     }
+  });
+}


### PR DESCRIPTION
This demonstrates a potential way to make integrating with the new router api a little bit easier.

The `$bindTo()` method of a firebase object will now accept a component, so you can do this:

```javascript
function EditMessageController($routeParams, $firebaseObject){
  this.messageId = $routeParams.messageId;
  var ref = new Firebase("https://fbbug.firebaseio.com/messages/" + this.messageId);
  var sync = $firebaseObject(ref);
  sync.$bindTo(this, 'message');
}
```
instead of the hacky workaround discussed in #597 

It introduces a new module that should be published as a separate distributable (it forces a dependency on `angular-new-router`).

