### PR TITLE
Fixes #411 - switch to $evalAsync() for improved performance

### DIFF
--- a/src/FirebaseArray.js
+++ b/src/FirebaseArray.js
@@ -624,14 +624,13 @@
         }
 
         var def     = $firebaseUtils.defer();
-        var batch   = $firebaseUtils.batch();
-        var created = batch(function(snap, prevChild) {
+        var created = $firebaseUtils.batch(function(snap, prevChild) {
           var rec = firebaseArray.$$added(snap, prevChild);
           if( rec ) {
             firebaseArray.$$process('child_added', rec, prevChild);
           }
         });
-        var updated = batch(function(snap) {
+        var updated = $firebaseUtils.batch(function(snap) {
           var rec = firebaseArray.$getRecord($firebaseUtils.getKey(snap));
           if( rec ) {
             var changed = firebaseArray.$$updated(snap);
@@ -640,7 +639,7 @@
             }
           }
         });
-        var moved   = batch(function(snap, prevChild) {
+        var moved   = $firebaseUtils.batch(function(snap, prevChild) {
           var rec = firebaseArray.$getRecord($firebaseUtils.getKey(snap));
           if( rec ) {
             var confirmed = firebaseArray.$$moved(snap, prevChild);
@@ -649,7 +648,7 @@
             }
           }
         });
-        var removed = batch(function(snap) {
+        var removed = $firebaseUtils.batch(function(snap) {
           var rec = firebaseArray.$getRecord($firebaseUtils.getKey(snap));
           if( rec ) {
             var confirmed = firebaseArray.$$removed(snap);
@@ -660,11 +659,11 @@
         });
 
         var isResolved = false;
-        var error   = batch(function(err) {
+        var error   = $firebaseUtils.batch(function(err) {
           _initComplete(err);
           firebaseArray.$$error(err);
         });
-        var initComplete = batch(_initComplete);
+        var initComplete = $firebaseUtils.batch(_initComplete);
 
         var sync = {
           destroy: destroy,

--- a/src/FirebaseObject.js
+++ b/src/FirebaseObject.js
@@ -433,8 +433,7 @@
 
         var isResolved = false;
         var def = $firebaseUtils.defer();
-        var batch = $firebaseUtils.batch();
-        var applyUpdate = batch(function(snap) {
+        var applyUpdate = $firebaseUtils.batch(function(snap) {
           var changed = firebaseObject.$$updated(snap);
           if( changed ) {
             // notifies $watch listeners and
@@ -442,8 +441,8 @@
             firebaseObject.$$notify();
           }
         });
-        var error = batch(firebaseObject.$$error, firebaseObject);
-        var initComplete = batch(_initComplete);
+        var error = $firebaseUtils.batch(firebaseObject.$$error, firebaseObject);
+        var initComplete = $firebaseUtils.batch(_initComplete);
 
         var sync = {
           isDestroyed: false,

--- a/src/module.js
+++ b/src/module.js
@@ -5,15 +5,6 @@
 // services will live.
   angular.module("firebase", [])
     //todo use $window
-    .value("Firebase", exports.Firebase)
-
-    // used in conjunction with firebaseUtils.debounce function, this is the
-    // amount of time we will wait for additional records before triggering
-    // Angular's digest scope to dirty check and re-render DOM elements. A
-    // larger number here significantly improves performance when working with
-    // big data sets that are frequently changing in the DOM, but delays the
-    // speed at which each record is rendered in real-time. A number less than
-    // 100ms will usually be optimal.
-    .value('firebaseBatchDelay', 50 /* milliseconds */);
+    .value("Firebase", exports.Firebase);
 
 })(window);

--- a/tests/unit/utils.spec.js
+++ b/tests/unit/utils.spec.js
@@ -46,8 +46,7 @@ describe('$firebaseUtils', function () {
 
     it('should trigger function with arguments', function() {
       var spy = jasmine.createSpy();
-      var batch = $utils.batch();
-      var b = batch(spy);
+      var b = $utils.batch(spy);
       b('foo', 'bar');
       $timeout.flush();
       expect(spy).toHaveBeenCalledWith('foo', 'bar');
@@ -55,8 +54,7 @@ describe('$firebaseUtils', function () {
 
     it('should queue up requests until timeout', function() {
       var spy = jasmine.createSpy();
-      var batch = $utils.batch();
-      var b = batch(spy);
+      var b = $utils.batch(spy);
       for(var i=0; i < 4; i++) {
         b(i);
       }
@@ -70,8 +68,7 @@ describe('$firebaseUtils', function () {
       var spy = jasmine.createSpy().and.callFake(function() {
         b = this;
       });
-      var batch = $utils.batch();
-      batch(spy, a)();
+      $utils.batch(spy, a)();
       $timeout.flush();
       expect(spy).toHaveBeenCalled();
       expect(b).toBe(a);


### PR DESCRIPTION
@jwngr please have a look. This implements the $evalAsync() approach and removes @jamestalmage 's "favorite" part of the code--the batching logic that was previously necessary to make the timing of all the events work with Angular's compiler. Less complex and faster. Wins all around.