### PR TITLE
array.$loaded should wait for all promises to resolve. Closes #629.

### DIFF
--- a/src/FirebaseArray.js
+++ b/src/FirebaseArray.js
@@ -632,7 +632,7 @@
         var def     = $firebaseUtils.defer();
         var created = function(snap, prevChild) {
           waitForResolution(firebaseArray.$$added(snap, prevChild), function(rec) {
-            firebaseArray.$$process('child_added', rec, prevChild)
+            firebaseArray.$$process('child_added', rec, prevChild);
           });
         };
         var updated = function(snap) {
@@ -663,7 +663,9 @@
         function waitForResolution(maybePromise, callback) {
           var promise = $q.when(maybePromise);
           promise.then(function(result){
-            if (result) callback(result);
+            if (result) {
+              callback(result);
+            }
           });
           if (!isResolved) {
             resolutionPromises.push(promise);

--- a/src/utils.js
+++ b/src/utils.js
@@ -182,16 +182,6 @@
 
           resolve: $q.when,
 
-          whenUnwrapped: function(possiblePromise, callback) {
-            if( possiblePromise ) {
-              utils.resolve(possiblePromise).then(function(res) {
-                if( res ) {
-                  callback(res);
-                }
-              });
-            }
-          },
-
           //TODO: Remove false branch and use only angular implementation when we drop angular 1.2.x support.
           promise: angular.isFunction($q) ? $q : Q,
 


### PR DESCRIPTION
When we added promise support for user-extendable functions in
`$firebaseArray`, the unintended consequense was that the `$loaded`
promise was resolving before updates from the server were populated
to the array. The solution is to accumulate any user returned promises,
and wait until they have all resolved.

Closes #629