### PR TITLE
Run CI against latest stable Node and use new Travis infra

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
-- '0.10'
+- stable
+sudo: false
 addons:
   sauce_connect: true
 before_install:


### PR DESCRIPTION
See [here](http://docs.travis-ci.com/user/migrating-from-legacy) for details on the new Travis infrastructure.