### PR TITLE
Upgraded Firebase dependency to 2.x.x

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -31,7 +31,7 @@
   ],
   "dependencies": {
     "angular": "1.3.x || 1.4.x",
-    "firebase": "2.2.x"
+    "firebase": "2.x.x"
   },
   "devDependencies": {
     "angular-mocks": "~1.3.11",

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,0 +1,1 @@
+feature - Upgraded Firebase dependency to 2.x.x.

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   ],
   "dependencies": {
     "angular": "1.3.x || 1.4.x",
-    "firebase": "2.2.x"
+    "firebase": "2.x.x"
   },
   "devDependencies": {
     "coveralls": "^2.11.2",


### PR DESCRIPTION
Fixes #653. Once this gets merged in, we can go ahead and cut a `1.1.3` release.