### PR TITLE
Drop bower as part of build (still deploy there)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,7 @@ install:
 - git clone git://github.com/n1k0/casperjs.git ~/casperjs
 - export PATH=$PATH:~/casperjs/bin
 - npm install -g grunt-cli
-- npm install -g bower
 - npm install
-- bower install
 before_script:
 - grunt install
 - phantomjs --version

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -139,7 +139,7 @@ module.exports = function(grunt) {
 
   // Installation
   grunt.registerTask('install', ['shell:protractor_install']);
-  grunt.registerTask('update', ['shell:npm_install', 'shell:bower_install']);
+  grunt.registerTask('update', ['shell:npm_install']);
 
   // Single run tests
   grunt.registerTask('test', ['test:unit', 'test:e2e']);

--- a/README.md
+++ b/README.md
@@ -81,9 +81,7 @@ environment set up:
 $ git clone https://github.com/firebase/angularfire.git
 $ cd angularfire            # go to the angularfire directory
 $ npm install -g grunt-cli  # globally install grunt task runner
-$ npm install -g bower      # globally install Bower package manager
 $ npm install               # install local npm build / test dependencies
-$ bower install             # install local JavaScript dependencies
 $ grunt install             # install Selenium server for end-to-end tests
 $ grunt watch               # watch for source file changes
 ```

--- a/bower.json
+++ b/bower.json
@@ -19,22 +19,11 @@
   ],
   "main": "dist/angularfire.js",
   "ignore": [
-    "**/.*",
-    "src",
-    "tests",
-    "node_modules",
-    "bower_components",
-    "firebase.json",
-    "package.json",
-    "Gruntfile.js",
-    "changelog.txt"
+    "**/*",
+    "!dist/angularfire.js"
   ],
   "dependencies": {
     "angular": "1.3.x || 1.4.x",
     "firebase": "2.x.x"
-  },
-  "devDependencies": {
-    "angular-mocks": "~1.4.6",
-    "mockfirebase": "~0.10.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "firebase": "2.x.x"
   },
   "devDependencies": {
+    "angular-mocks": "~1.4.6",
     "coveralls": "^2.11.2",
     "grunt": "~0.4.5",
     "grunt-cli": "^0.1.13",
@@ -61,6 +62,7 @@
     "karma-sauce-launcher": "~0.2.10",
     "karma-spec-reporter": "0.0.16",
     "load-grunt-tasks": "^3.1.0",
+    "mockfirebase": "jamestalmage/mockfirebase#deploy-npmignore-fix",
     "protractor": "^1.6.1"
   }
 }

--- a/tests/automatic_karma.conf.js
+++ b/tests/automatic_karma.conf.js
@@ -29,9 +29,9 @@ module.exports = function(config) {
     },
 
     files: [
-      '../bower_components/angular/angular.js',
-      '../bower_components/angular-mocks/angular-mocks.js',
-      '../bower_components/mockfirebase/browser/mockfirebase.js',
+      '../node_modules/angular/angular.js',
+      '../node_modules/angular-mocks/angular-mocks.js',
+      '../node_modules/mockfirebase/browser/mockfirebase.js',
       'lib/**/*.js',
       '../src/module.js',
       '../src/**/*.js',

--- a/tests/manual_karma.conf.js
+++ b/tests/manual_karma.conf.js
@@ -10,9 +10,9 @@ module.exports = function(config) {
     singleRun: false,
 
     files: [
-      '../bower_components/angular/angular.js',
-      '../bower_components/angular-mocks/angular-mocks.js',
-      '../bower_components/firebase/firebase.js',
+      '../node_modules/angular/angular.js',
+      '../node_modules/angular-mocks/angular-mocks.js',
+      '../node_modules/firebase/lib/firebase-web.js',
       '../src/module.js',
       '../src/**/*.js',
       'manual/**/*.spec.js'

--- a/tests/protractor/chat/chat.html
+++ b/tests/protractor/chat/chat.html
@@ -4,10 +4,10 @@
     <title>AngularFire Chat e2e Test</title>
 
     <!-- Angular -->
-    <script src="../../../bower_components/angular/angular.min.js"></script>
+    <script src="../../../node_modules/angular/angular.min.js"></script>
 
     <!-- Firebase -->
-    <script src="../../../bower_components/firebase/firebase.js"></script>
+    <script src="../../../node_modules/firebase/lib/firebase-web.js"></script>
 
     <!-- AngularFire -->
     <script src="../../../dist/angularfire.js"></script>

--- a/tests/protractor/priority/priority.html
+++ b/tests/protractor/priority/priority.html
@@ -4,10 +4,10 @@
     <title>AngularFire Priority e2e Test</title>
 
     <!-- Angular -->
-    <script src="../../../bower_components/angular/angular.min.js"></script>
+    <script src="../../../node_modules/angular/angular.min.js"></script>
 
     <!-- Firebase -->
-    <script src="../../../bower_components/firebase/firebase.js"></script>
+    <script src="../../../node_modules/firebase/lib/firebase-web.js"></script>
 
     <!-- AngularFire -->
     <script src="../../../dist/angularfire.js"></script>

--- a/tests/protractor/tictactoe/tictactoe.html
+++ b/tests/protractor/tictactoe/tictactoe.html
@@ -4,10 +4,10 @@
     <title>AngularFire TicTacToe e2e Test</title>
 
     <!-- Angular -->
-    <script src="../../../bower_components/angular/angular.min.js"></script>
+    <script src="../../../node_modules/angular/angular.min.js"></script>
 
     <!-- Firebase -->
-    <script src="../../../bower_components/firebase/firebase.js"></script>
+    <script src="../../../node_modules/firebase/lib/firebase-web.js"></script>
 
     <!-- AngularFire -->
     <script src="../../../dist/angularfire.js"></script>

--- a/tests/protractor/todo/todo.html
+++ b/tests/protractor/todo/todo.html
@@ -4,10 +4,10 @@
     <title>AngularFire Todo e2e Test</title>
 
     <!-- Angular -->
-    <script src="../../../bower_components/angular/angular.min.js"></script>
+    <script src="../../../node_modules/angular/angular.min.js"></script>
 
     <!-- Firebase -->
-    <script src="../../../bower_components/firebase/firebase.js"></script>
+    <script src="../../../node_modules/firebase/lib/firebase-web.js"></script>
 
     <!-- AngularFire -->
     <script src="../../../dist/angularfire.js"></script>

--- a/tests/sauce_karma.conf.js
+++ b/tests/sauce_karma.conf.js
@@ -18,9 +18,9 @@ module.exports = function(config) {
     basePath: '',
     frameworks: ['jasmine'],
     files: [
-      '../bower_components/angular/angular.js',
-      '../bower_components/angular-mocks/angular-mocks.js',
-      '../bower_components/mockfirebase/browser/mockfirebase.js',
+      '../node_modules/angular/angular.js',
+      '../node_modules/angular-mocks/angular-mocks.js',
+      '../node_modules/mockfirebase/browser/mockfirebase.js',
       'lib/**/*.js',
       '../dist/angularfire.js',
       'mocks/**/*.js',


### PR DESCRIPTION
The extra build step does not make any sense.

Not suggesting we drop bower completely (we should still deploy there for users still using bower).

`mockfirebase` is the only blocker (it does not publish a browserified build to the npm registry). I have already [submitted a PR](https://github.com/katowulf/mockfirebase/pull/96). I would hold off until that is merged and I update this PR after it is published.

