### PR TITLE
Updated format of package.json's license field

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,12 +11,7 @@
   "bugs": {
     "url": "https://github.com/firebase/angularfire/issues"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "http://firebase.mit-license.org/"
-    }
-  ],
+  "license": "MIT",
   "keywords": [
     "angular",
     "angularjs",


### PR DESCRIPTION
As per [the documentation `package.json`](https://docs.npmjs.com/files/package.json#license), the `licenses` field we are using is deprecated and throws a warning every time you try to `npm install angularfire`. This PR updates our `package.json` to use the `license` field with the correct format.