### PR TITLE
Fixes to drop-bower PR

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,9 +21,8 @@
   "ignore": [
     "**/*",
     "!dist/*.js",
-    "!*.md",
-    "!*.txt",
-    "!index.js"
+    "!README.md",
+    "!LICENSE"
   ],
   "dependencies": {
     "angular": "1.3.x || 1.4.x",

--- a/bower.json
+++ b/bower.json
@@ -20,7 +20,10 @@
   "main": "dist/angularfire.js",
   "ignore": [
     "**/*",
-    "!dist/angularfire.js"
+    "!dist/*.js",
+    "!*.md",
+    "!*.txt",
+    "!index.js"
   ],
   "dependencies": {
     "angular": "1.3.x || 1.4.x",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "karma-sauce-launcher": "~0.2.10",
     "karma-spec-reporter": "0.0.16",
     "load-grunt-tasks": "^3.1.0",
-    "mockfirebase": "jamestalmage/mockfirebase#deploy-npmignore-fix",
+    "mockfirebase": "^0.12.0",
     "protractor": "^1.6.1"
   }
 }


### PR DESCRIPTION
Same branch as #656, but that was merged and reverted.

The fixes are here.

I updated to `0.12.0` in the blind. I haven't actually run the build against it (it will certainly fail since `0.12.0` isn't in npm yet).

@katowulf - you should be able to re-trigger the travis build once mockfirebase is published to npm.