### PR TITLE
Ensure all global dependencies are loaded for CommonJS

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,2 +1,9 @@
+// Make sure dependencies are loaded on the window
+require('angular');
+require('firebase');
+
+// Load the Angular module which uses window.angular and window.Firebase
 require('./dist/angularfire');
+
+// Export the module name from the Angular module
 module.exports = 'firebase';

--- a/package.json
+++ b/package.json
@@ -26,13 +26,15 @@
     "README.md",
     "package.json"
   ],
-  "dependencies": {
+  "peerDependencies": {
     "angular": "^1.3.0",
     "firebase": "2.x.x"
   },
   "devDependencies": {
+    "angular": "^1.3.0",
     "angular-mocks": "~1.4.6",
     "coveralls": "^2.11.2",
+    "firebase": "2.x.x",
     "grunt": "~0.4.5",
     "grunt-cli": "^0.1.13",
     "grunt-contrib-concat": "^0.5.0",


### PR DESCRIPTION
Closes #707

As always, some users will have inevitably depended on the old, incorrect behavior. It's possible, for example, they were loading Firebase from the CDN but also using Browserify for their Angular project. 

This might be useful for someone in that sorta situation:

https://github.com/thlorenz/exposify

I'm sure there's a Webpack equivalent. 