### PR TITLE
Re-added Firebase as a regular dep in package.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
   "description": "The officially supported AngularJS binding for Firebase",
   "version": "0.0.0",
   "authors": [
-    "Firebase <support@firebase.com> (https://www.firebase.com/)"
+    "Firebase (https://firebase.google.com/)"
   ],
   "homepage": "https://github.com/firebase/angularfire",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "angularfire",
   "description": "The officially supported AngularJS binding for Firebase",
   "version": "0.0.0",
-  "author": "Firebase <support@firebase.com> (https://www.firebase.com/)",
+  "author": "Firebase (https://firebase.google.com/)",
   "homepage": "https://github.com/firebase/angularfire",
   "repository": {
     "type": "git",
@@ -26,6 +26,9 @@
     "README.md",
     "package.json"
   ],
+  "dependencies": {
+    "firebase": "3.x.x"
+  },
   "peerDependencies": {
     "angular": "^1.3.0",
     "firebase": "3.x.x"
@@ -34,7 +37,6 @@
     "angular": "^1.3.0",
     "angular-mocks": "~1.4.6",
     "coveralls": "^2.11.2",
-    "firebase": "2.x.x",
     "grunt": "~0.4.5",
     "grunt-cli": "^0.1.13",
     "grunt-contrib-concat": "^0.5.0",


### PR DESCRIPTION
See [this Twitter discussion](https://twitter.com/_jwngr/status/714581777612808193) for the reason why Firebase should be both a regular dependency and a peer dependency. We do [the same thing with Firebase Queue](https://github.com/firebase/firebase-queue/blob/f9915c91e8572fdb47c3ae8aa7bc67c170b26047/package.json#L31-L35).

Also getting rid of old support email and updating the Firebase website in the `package.json` and `bower.json`.