### PR TITLE
Fix ServerValue.TIMESTAMP usage in docs

### DIFF
--- a/docs/guide/synchronized-arrays.md
+++ b/docs/guide/synchronized-arrays.md
@@ -160,7 +160,7 @@ app.controller("ChatCtrl", ["$scope", "chatMessages",
       $scope.messages.$add({
         from: $scope.user,
         content: $scope.message,
-        timestamp: Firebase.ServerValue.TIMESTAMP
+        timestamp: firebase.database.ServerValue.TIMESTAMP
       });
 
       $scope.message = "";
@@ -172,7 +172,7 @@ app.controller("ChatCtrl", ["$scope", "chatMessages",
         $scope.messages.$add({
           from: "Uri",
           content: "Hello!",
-          timestamp: Firebase.ServerValue.TIMESTAMP
+          timestamp: firebase.database.ServerValue.TIMESTAMP
         });
       }
     });


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Make sure your changes pass our linter and the tests all pass on your local machine. We've hooked
up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->


### Description

Update the docs with correct reference to ServerValue.TIMESTAMP.
