### PR TITLE
Removed promise utils in favor of $q

### DIFF
--- a/src/FirebaseArray.js
+++ b/src/FirebaseArray.js
@@ -110,7 +110,7 @@
         $add: function(data) {
           this._assertNotDestroyed('$add');
           var self = this;
-          var def = $firebaseUtils.defer();
+          var def = $q.defer();
           var ref = this.$ref().ref.push();
           var dataJSON;
 
@@ -149,7 +149,7 @@
           var self = this;
           var item = self._resolveItem(indexOrItem);
           var key = self.$keyAt(item);
-          var def = $firebaseUtils.defer();
+          var def = $q.defer();
 
           if( key !== null ) {
             var ref = self.$ref().ref.child(key);
@@ -199,7 +199,7 @@
             });
           }
           else {
-            return $firebaseUtils.reject('Invalid record; could not determine key for '+indexOrItem);
+            return $q.reject('Invalid record; could not determine key for '+indexOrItem);
           }
         },
 
@@ -655,7 +655,7 @@
           }
         }
 
-        var def     = $firebaseUtils.defer();
+        var def = $q.defer();
         var created = function(snap, prevChild) {
           if (!firebaseArray) {
             return;

--- a/src/FirebaseAuth.js
+++ b/src/FirebaseAuth.js
@@ -4,7 +4,7 @@
 
   // Define a service which provides user authentication and management.
   angular.module('firebase').factory('$firebaseAuth', [
-    '$firebaseUtils', function($firebaseUtils) {
+    '$q', '$firebaseUtils', function($q, $firebaseUtils) {
       /**
        * This factory returns an object allowing you to manage the client's authentication state.
        *
@@ -15,13 +15,14 @@
       return function(auth) {
         auth = auth || firebase.auth();
 
-        var firebaseAuth = new FirebaseAuth($firebaseUtils, auth);
+        var firebaseAuth = new FirebaseAuth($q, $firebaseUtils, auth);
         return firebaseAuth.construct();
       };
     }
   ]);
 
-  FirebaseAuth = function($firebaseUtils, auth) {
+  FirebaseAuth = function($q, $firebaseUtils, auth) {
+    this._q = $q;
     this._utils = $firebaseUtils;
     if (typeof ref === 'string') {
       throw new Error('Please provide a Firebase reference instead of a URL when creating a `$firebaseAuth` object.');
@@ -76,7 +77,7 @@
      * @return {Promise<Object>} A promise fulfilled with an object containing authentication data.
      */
     signInWithCustomToken: function(authToken) {
-      return this._utils.promise.when(this._auth.signInWithCustomToken(authToken));
+      return this._q.when(this._auth.signInWithCustomToken(authToken));
     },
 
     /**
@@ -85,7 +86,7 @@
      * @return {Promise<Object>} A promise fulfilled with an object containing authentication data.
      */
     signInAnonymously: function() {
-      return this._utils.promise.when(this._auth.signInAnonymously());
+      return this._q.when(this._auth.signInAnonymously());
     },
 
     /**
@@ -96,7 +97,7 @@
      * @return {Promise<Object>} A promise fulfilled with an object containing authentication data.
      */
     signInWithEmailAndPassword: function(email, password) {
-      return this._utils.promise.when(this._auth.signInWithEmailAndPassword(email, password));
+      return this._q.when(this._auth.signInWithEmailAndPassword(email, password));
     },
 
     /**
@@ -106,7 +107,7 @@
      * @return {Promise<Object>} A promise fulfilled with an object containing authentication data.
      */
     signInWithPopup: function(provider) {
-      return this._utils.promise.when(this._auth.signInWithPopup(this._getProvider(provider)));
+      return this._q.when(this._auth.signInWithPopup(this._getProvider(provider)));
     },
 
     /**
@@ -116,7 +117,7 @@
      * @return {Promise<Object>} A promise fulfilled with an object containing authentication data.
      */
     signInWithRedirect: function(provider) {
-      return this._utils.promise.when(this._auth.signInWithRedirect(this._getProvider(provider)));
+      return this._q.when(this._auth.signInWithRedirect(this._getProvider(provider)));
     },
 
     /**
@@ -126,7 +127,7 @@
      * @return {Promise<Object>} A promise fulfilled with an object containing authentication data.
      */
     signInWithCredential: function(credential) {
-      return this._utils.promise.when(this._auth.signInWithCredential(credential));
+      return this._q.when(this._auth.signInWithCredential(credential));
     },
 
     /**
@@ -191,10 +192,10 @@
         // to the current auth state and not a stale/initial state
         var authData = self.getAuth(), res = null;
         if (rejectIfAuthDataIsNull && authData === null) {
-          res = self._utils.reject("AUTH_REQUIRED");
+          res = self._q.reject("AUTH_REQUIRED");
         }
         else {
-          res = self._utils.resolve(authData);
+          res = self._q.when(authData);
         }
         return res;
       });
@@ -226,7 +227,7 @@
     _initAuthResolver: function() {
       var auth = this._auth;
 
-      return this._utils.promise(function(resolve) {
+      return this._q(function(resolve) {
         var off;
         function callback() {
           // Turn off this onAuthStateChanged() callback since we just needed to get the authentication data once.
@@ -274,7 +275,7 @@
      * uid of the created user.
      */
     createUserWithEmailAndPassword: function(email, password) {
-      return this._utils.promise.when(this._auth.createUserWithEmailAndPassword(email, password));
+      return this._q.when(this._auth.createUserWithEmailAndPassword(email, password));
     },
 
     /**
@@ -286,9 +287,9 @@
     updatePassword: function(password) {
       var user = this.getAuth();
       if (user) {
-        return this._utils.promise.when(user.updatePassword(password));
+        return this._q.when(user.updatePassword(password));
       } else {
-        return this._utils.reject("Cannot update password since there is no logged in user.");
+        return this._q.reject("Cannot update password since there is no logged in user.");
       }
     },
 
@@ -301,9 +302,9 @@
     updateEmail: function(email) {
       var user = this.getAuth();
       if (user) {
-        return this._utils.promise.when(user.updateEmail(email));
+        return this._q.when(user.updateEmail(email));
       } else {
-        return this._utils.reject("Cannot update email since there is no logged in user.");
+        return this._q.reject("Cannot update email since there is no logged in user.");
       }
     },
 
@@ -315,9 +316,9 @@
     deleteUser: function() {
       var user = this.getAuth();
       if (user) {
-        return this._utils.promise.when(user.delete());
+        return this._q.when(user.delete());
       } else {
-        return this._utils.reject("Cannot delete user since there is no logged in user.");
+        return this._q.reject("Cannot delete user since there is no logged in user.");
       }
     },
 
@@ -329,7 +330,7 @@
      * @return {Promise<>} An empty promise fulfilled once the reset password email is sent.
      */
     sendPasswordResetEmail: function(email) {
-      return this._utils.promise.when(this._auth.sendPasswordResetEmail(email));
+      return this._q.when(this._auth.sendPasswordResetEmail(email));
     }
   };
 })();

--- a/src/FirebaseObject.js
+++ b/src/FirebaseObject.js
@@ -23,8 +23,8 @@
    * </code></pre>
    */
   angular.module('firebase').factory('$firebaseObject', [
-    '$parse', '$firebaseUtils', '$log',
-    function($parse, $firebaseUtils, $log) {
+    '$parse', '$firebaseUtils', '$log', '$q',
+    function($parse, $firebaseUtils, $log, $q) {
       /**
        * Creates a synchronized object with 2-way bindings between Angular and Firebase.
        *
@@ -73,7 +73,7 @@
         $save: function () {
           var self = this;
           var ref = self.$ref();
-          var def = $firebaseUtils.defer();
+          var def = $q.defer();
           var dataJSON;
 
           try {
@@ -240,7 +240,7 @@
         $$scopeUpdated: function(newData) {
           // we use a one-directional loop to avoid feedback with 3-way bindings
           // since set() is applied locally anyway, this is still performant
-          var def = $firebaseUtils.defer();
+          var def = $q.defer();
           this.$ref().set($firebaseUtils.toJSON(newData), $firebaseUtils.makeNodeResolver(def));
           return def.promise;
         },
@@ -330,7 +330,7 @@
               this.key + '; one binding per instance ' +
               '(call unbind method or create another FirebaseObject instance)';
             $log.error(msg);
-            return $firebaseUtils.reject(msg);
+            return $q.reject(msg);
           }
         },
 
@@ -450,7 +450,7 @@
         }
 
         var isResolved = false;
-        var def = $firebaseUtils.defer();
+        var def = $q.defer();
         var applyUpdate = $firebaseUtils.batch(function(snap) {
           var changed = firebaseObject.$$updated(snap);
           if( changed ) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -153,14 +153,6 @@
             });
           },
 
-          defer: $q.defer,
-
-          reject: $q.reject,
-
-          resolve: $q.when,
-
-          promise: $q,
-
           makeNodeResolver:function(deferred){
             return function(err,result){
               if(err === null){
@@ -332,7 +324,7 @@
           },
 
           doSet: function(ref, data) {
-            var def = utils.defer();
+            var def = $q.defer();
             if( angular.isFunction(ref.set) || !angular.isObject(data) ) {
               // this is not a query, just do a flat set
               // Use try / catch to handle being passed data which is undefined or has invalid keys
@@ -362,7 +354,7 @@
           },
 
           doRemove: function(ref) {
-            var def = utils.defer();
+            var def = $q.defer();
             if( angular.isFunction(ref.remove) ) {
               // ref is not a query, just do a flat remove
               ref.remove(utils.makeNodeResolver(def));

--- a/tests/unit/FirebaseArray.spec.js
+++ b/tests/unit/FirebaseArray.spec.js
@@ -98,7 +98,7 @@ describe('$firebaseArray', function () {
     it('should wait for promise resolution to update array', function () {
       var queue = [];
       function addPromise(snap, prevChild){
-        return new $utils.promise(
+        return $q(
           function(resolve) {
             queue.push(resolve);
           }).then(function(name) {
@@ -122,7 +122,7 @@ describe('$firebaseArray', function () {
     it('should wait to resolve $loaded until $$added promise is resolved', function () {
       var queue = [];
       function addPromise(snap, prevChild){
-        return new $utils.promise(
+        return $q(
           function(resolve) {
             queue.push(resolve);
           }).then(function(name) {


### PR DESCRIPTION
We no longer need these promise utils as they just use `$q` anyway. We can make the code easier to read by just removing the unnecessary abstraction.

This resolves some of the things mentioned in https://github.com/firebase/angularfire/issues/630.