### PR TITLE
Add in missing migration info

### DIFF
--- a/docs/migration/1XX-to-2XX.md
+++ b/docs/migration/1XX-to-2XX.md
@@ -54,8 +54,6 @@ Several authentication methods have been renamed and / or have different method 
 | `$resetPassword(credentials)` | `$sendPasswordResetEmail(email)` | |
 | `$unauth()` | `$signOut()` | |
 | `$onAuth(callback)` | `$onAuthStateChanged(callback)` | |
-| `$onAuth(callback)` | `$onAuthStateChanged(callback)` | |
-| `$onAuth(callback)` | `$onAuthStateChanged(callback)` | |
 | `$requireAuth()` | `$requireSignIn()` | |
 | `$waitForAuth()` | `$waitForSignIn()` | |
 

--- a/docs/migration/1XX-to-2XX.md
+++ b/docs/migration/1XX-to-2XX.md
@@ -54,7 +54,10 @@ Several authentication methods have been renamed and / or have different method 
 | `$resetPassword(credentials)` | `$sendPasswordResetEmail(email)` | |
 | `$unauth()` | `$signOut()` | |
 | `$onAuth(callback)` | `$onAuthStateChanged(callback)` | |
-
+| `$onAuth(callback)` | `$onAuthStateChanged(callback)` | |
+| `$onAuth(callback)` | `$onAuthStateChanged(callback)` | |
+| `$requireAuth()` | `$requireSignIn()` | |
+| `$waitForAuth()` | `$waitForSignIn()` | |
 
 ## Auth Payload Format Changes
 


### PR DESCRIPTION
I just added in extra documentation for the migration docs (as I didn't see it there):

`$requireAuth()` -> `$requireSignIn()`
`$waitForAuth()` -> `$waitForSignIn()`