### PR TITLE
Fixed a small typo

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -207,7 +207,7 @@ obj.$loaded(
 Returns the `Firebase` reference used to create this object.
 
 ```js
-var ob = $firebaseObject(ref);
+var obj = $firebaseObject(ref);
 obj.$ref() === ref; // true
 ```
 


### PR DESCRIPTION
### Description

I just fix a small typo


### Code sample

 ```js
-var ob = $firebaseObject(ref);
+var obj = $firebaseObject(ref);
 obj.$ref() === ref; // true
 ```
