### PR TITLE
Add requireEmailVerification argument to $requireSignIn() firebase auth router helper

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -43,8 +43,7 @@
     * [`$sendPasswordResetEmail(email)`](#sendpasswordresetemailemail)
   * Router Helpers
     * [`$waitForSignIn()`](#waitforsignin)
-    * [`$requireSignIn()`](#requiresignin)
-    * [`$requireEmailVerification()`](#requireemailverification)
+    * [`$requireSignIn(requireEmailVerification)`](#requiresignin)
 * [Extending the Services](#extending-the-services)
   * [Extending `$firebaseObject`](#extending-firebaseobject)
   * [Extending `$firebaseArray`](#extending-firebasearray)
@@ -895,24 +894,14 @@ intended to be used in the `resolve()` method of Angular routers. See the
 ["Using Authentication with Routers"](/docs/guide/user-auth.md#authenticating-with-routers)
 section of our AngularFire guide for more information and a full example.
 
-### $requireSignIn()
+### $requireSignIn(requireEmailVerification)
 
 Helper method which returns a promise fulfilled with the current authentication state if the user
-is authenticated but otherwise rejects the promise. This is intended to be used in the `resolve()`
-method of Angular routers to prevented unauthenticated users from seeing authenticated pages
-momentarily during page load. See the
+is authenticated and, if specified, has a verified email address, but otherwise rejects the promise. 
+This is intended to be used in the `resolve()` method of Angular routers to prevented unauthenticated 
+users from seeing authenticated pages momentarily during page load. See the
 ["Using Authentication with Routers"](/docs/guide/user-auth.md#authenticating-with-routers)
 section of our AngularFire guide for more information and a full example.
-
-### $requireEmailVerification()
-
-Helper method which returns a promise fulfilled with the current authentication state if the user
-is authenticated and has a verified email addres but otherwise rejects the promise. This is intended 
-to be used in the `resolve()` method of Angular routers to prevented unauthenticated/unverified users from seeing 
-authenticated pages momentarily during page load. See the
-["Using Authentication with Routers"](/docs/guide/user-auth.md#authenticating-with-routers)
-section of our AngularFire guide for more information and a full example.
-
 
 ## Extending the Services
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -44,7 +44,7 @@
   * Router Helpers
     * [`$waitForSignIn()`](#waitforsignin)
     * [`$requireSignIn()`](#requiresignin)
-	* [`$requireEmailVerification()`](#requireemailverification)
+    * [`$requireEmailVerification()`](#requireemailverification)
 * [Extending the Services](#extending-the-services)
   * [Extending `$firebaseObject`](#extending-firebaseobject)
   * [Extending `$firebaseArray`](#extending-firebasearray)

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -44,6 +44,7 @@
   * Router Helpers
     * [`$waitForSignIn()`](#waitforsignin)
     * [`$requireSignIn()`](#requiresignin)
+	* [`$requireEmailVerification()`](#requireemailverification)
 * [Extending the Services](#extending-the-services)
   * [Extending `$firebaseObject`](#extending-firebaseobject)
   * [Extending `$firebaseArray`](#extending-firebasearray)
@@ -900,6 +901,15 @@ Helper method which returns a promise fulfilled with the current authentication 
 is authenticated but otherwise rejects the promise. This is intended to be used in the `resolve()`
 method of Angular routers to prevented unauthenticated users from seeing authenticated pages
 momentarily during page load. See the
+["Using Authentication with Routers"](/docs/guide/user-auth.md#authenticating-with-routers)
+section of our AngularFire guide for more information and a full example.
+
+### $requireEmailVerification()
+
+Helper method which returns a promise fulfilled with the current authentication state if the user
+is authenticated and has a verified email addres but otherwise rejects the promise. This is intended 
+to be used in the `resolve()` method of Angular routers to prevented unauthenticated/unverified users from seeing 
+authenticated pages momentarily during page load. See the
 ["Using Authentication with Routers"](/docs/guide/user-auth.md#authenticating-with-routers)
 section of our AngularFire guide for more information and a full example.
 

--- a/src/auth/FirebaseAuth.js
+++ b/src/auth/FirebaseAuth.js
@@ -203,7 +203,7 @@
           res = self._q.reject("AUTH_REQUIRED");
         }
         else if (rejectIfEmailNotVerified && !authData.emailVerified) {
-            res = self._q.reject("EMAIL_NOT_VERIFIED");
+            res = self._q.reject("EMAIL_VERIFICATION_REQUIRED");
         }
         else {
           res = self._q.when(authData);

--- a/src/auth/FirebaseAuth.js
+++ b/src/auth/FirebaseAuth.js
@@ -52,7 +52,7 @@
         $getAuth: this.getAuth.bind(this),
         $requireSignIn: this.requireSignIn.bind(this),
         $waitForSignIn: this.waitForSignIn.bind(this),
-		$requireEmailVerification: this.requireEmailVerification.bind(this),
+        $requireEmailVerification: this.requireEmailVerification.bind(this),
 
         // User management methods
         $createUserWithEmailAndPassword: this.createUserWithEmailAndPassword.bind(this),
@@ -203,9 +203,9 @@
         if (rejectIfAuthDataIsNull && authData === null) {
           res = self._q.reject("AUTH_REQUIRED");
         }
-		else if (rejectIfEmailNotVerified && !authData.emailVerified) {
-			res = self._q.reject("EMAIL_NOT_VERIFIED");
-		}
+        else if (rejectIfEmailNotVerified && !authData.emailVerified) {
+            res = self._q.reject("EMAIL_NOT_VERIFIED");
+        }
         else {
           res = self._q.when(authData);
         }
@@ -272,7 +272,7 @@
       return this._routerMethodOnAuthPromise(false, false);
     },
 
-	/**
+    /**
      * Utility method which can be used in a route's resolve() method to require that a route has
      * a logged in client with a verified email address.
      *
@@ -280,7 +280,7 @@
      * state or rejected if the client is not authenticated and/or does not have a verified email address.
      */
     requireEmailVerification: function() {
-		return this._routerMethodOnAuthPromise(true, true);
+        return this._routerMethodOnAuthPromise(true, true);
     },
 	
     /*********************/

--- a/src/auth/FirebaseAuth.js
+++ b/src/auth/FirebaseAuth.js
@@ -185,8 +185,8 @@
      *
      * @param {boolean} rejectIfAuthDataIsNull Determines if the returned promise should be
      * resolved or rejected upon an unauthenticated client.
-	 * @param {boolean} rejectIfEmailNotVerified Determines if the returned promise should be 
-	 * resolved or rejected upon a client without a verified email address.
+     * @param {boolean} rejectIfEmailNotVerified Determines if the returned promise should be 
+     * resolved or rejected upon a client without a verified email address.
      * @return {Promise<Object>} A promise fulfilled with the client's authentication state or
      * rejected if the client is unauthenticated and rejectIfAuthDataIsNull is true.
      */

--- a/src/auth/FirebaseAuth.js
+++ b/src/auth/FirebaseAuth.js
@@ -52,7 +52,6 @@
         $getAuth: this.getAuth.bind(this),
         $requireSignIn: this.requireSignIn.bind(this),
         $waitForSignIn: this.waitForSignIn.bind(this),
-        $requireEmailVerification: this.requireEmailVerification.bind(this),
 
         // User management methods
         $createUserWithEmailAndPassword: this.createUserWithEmailAndPassword.bind(this),
@@ -254,11 +253,13 @@
      * Utility method which can be used in a route's resolve() method to require that a route has
      * a logged in client.
      *
+     * @param {boolean} requireEmailVerification Determines if the route requires a client with a verified 
+     * verified email address.
      * @returns {Promise<Object>} A promise fulfilled with the client's current authentication
      * state or rejected if the client is not authenticated.
      */
-    requireSignIn: function() {
-      return this._routerMethodOnAuthPromise(true, false);
+    requireSignIn: function(requireEmailVerification) {
+      return this._routerMethodOnAuthPromise(true, requireEmailVerification);
     },
 
     /**
@@ -270,17 +271,6 @@
      */
     waitForSignIn: function() {
       return this._routerMethodOnAuthPromise(false, false);
-    },
-
-    /**
-     * Utility method which can be used in a route's resolve() method to require that a route has
-     * a logged in client with a verified email address.
-     *
-     * @returns {Promise<Object>} A promise fulfilled with the client's current authentication
-     * state or rejected if the client is not authenticated and/or does not have a verified email address.
-     */
-    requireEmailVerification: function() {
-        return this._routerMethodOnAuthPromise(true, true);
     },
 	
     /*********************/

--- a/src/auth/FirebaseAuth.js
+++ b/src/auth/FirebaseAuth.js
@@ -253,7 +253,7 @@
      * Utility method which can be used in a route's resolve() method to require that a route has
      * a logged in client.
      *
-     * @param {boolean} requireEmailVerification Determines if the route requires a client with a verified 
+     * @param {boolean} requireEmailVerification Determines if the route requires a client with a 
      * verified email address.
      * @returns {Promise<Object>} A promise fulfilled with the client's current authentication
      * state or rejected if the client is not authenticated.

--- a/tests/unit/FirebaseAuth.spec.js
+++ b/tests/unit/FirebaseAuth.spec.js
@@ -384,7 +384,57 @@ describe('FirebaseAuth',function(){
       tick();
     });
   });
+  
+  describe('$requireSignIn(requireEmailVerification)',function(){	
+    it('will be resolved if user is logged in and has a verified email address', function(done){
+      var credentials = {provider: 'facebook', emailVerified: true};
+      spyOn(authService._, 'getAuth').and.callFake(function () {
+        return credentials;
+      });
 
+      authService.$requireSignIn(true)
+        .then(function (result) {
+          expect(result).toEqual(credentials);
+          done();
+        });
+
+      fakePromiseResolve(credentials);
+      tick();
+    });
+	
+	it('will be resolved if user is logged in and we ignore email verification', function(done){
+      var credentials = {provider: 'facebook', emailVerified: false};
+      spyOn(authService._, 'getAuth').and.callFake(function () {
+        return credentials;
+      });
+
+      authService.$requireSignIn(false)
+        .then(function (result) {
+          expect(result).toEqual(credentials);
+          done();
+        });
+
+      fakePromiseResolve(credentials);
+      tick();
+    });
+	
+	it('will be rejected if user does not have a verified email address', function(done){
+      var credentials = {provider: 'facebook', emailVerified: false};
+      spyOn(authService._, 'getAuth').and.callFake(function () {
+        return credentials;
+      });
+
+      authService.$requireSignIn(true)
+		.catch(function (error) {
+          expect(error).toEqual('EMAIL_VERIFICATION_REQUIRED');
+          done();
+        });
+
+      fakePromiseResolve(credentials);
+      tick();
+    });
+  });  
+  
   describe('$waitForSignIn()',function(){
     it('will be resolved with authData if user is logged in', function(done){
       var credentials = {provider: 'facebook'};

--- a/tests/unit/FirebaseAuth.spec.js
+++ b/tests/unit/FirebaseAuth.spec.js
@@ -402,7 +402,7 @@ describe('FirebaseAuth',function(){
       tick();
     });
 	
-	it('will be resolved if user is logged in and we ignore email verification', function(done){
+    it('will be resolved if user is logged in and we ignore email verification', function(done){
       var credentials = {provider: 'facebook', emailVerified: false};
       spyOn(authService._, 'getAuth').and.callFake(function () {
         return credentials;
@@ -418,17 +418,17 @@ describe('FirebaseAuth',function(){
       tick();
     });
 	
-	it('will be rejected if user does not have a verified email address', function(done){
-      var credentials = {provider: 'facebook', emailVerified: false};
-      spyOn(authService._, 'getAuth').and.callFake(function () {
-        return credentials;
-      });
+   it('will be rejected if user does not have a verified email address', function(done){
+     var credentials = {provider: 'facebook', emailVerified: false};
+     spyOn(authService._, 'getAuth').and.callFake(function () {
+       return credentials;
+     });
 
       authService.$requireSignIn(true)
-		.catch(function (error) {
+        .catch(function (error) {
           expect(error).toEqual('EMAIL_VERIFICATION_REQUIRED');
           done();
-        });
+      });
 
       fakePromiseResolve(credentials);
       tick();


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Make sure your changes pass our linter and the tests all pass on your local machine. We've hooked
up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->


### Description

This adds an argument (requireEmailVerification) to the $requireSignIn router helper in the angularfire auth service.
When set to true, this will fail if the firebase auth "emailVerified" property is false.
This is useful if you do not want users to access your app until they have verified their email address.

### Code sample

```javascript
_routerMethodOnAuthPromise: function(rejectIfAuthDataIsNull, rejectIfEmailNotVerified) {
      var self = this;

      // wait for the initial auth state to resolve; on page load we have to request auth state
      // asynchronously so we don't want to resolve router methods or flash the wrong state
      return this._initialAuthResolver.then(function() {
        // auth state may change in the future so rather than depend on the initially resolved state
        // we also check the auth data (synchronously) if a new promise is requested, ensuring we resolve
        // to the current auth state and not a stale/initial state
        var authData = self.getAuth(), res = null;
        if (rejectIfAuthDataIsNull && authData === null) {
          res = self._q.reject("AUTH_REQUIRED");
        }
        else if (rejectIfEmailNotVerified && !authData.emailVerified) {
            res = self._q.reject("EMAIL_NOT_VERIFIED");
        }
        else {
          res = self._q.when(authData);
        }
        return res;
      });
    },
```
