### PR TITLE
Fix firebaseObject destroyed caused delayed on('value') update failure.

### DIFF
--- a/src/database/FirebaseObject.js
+++ b/src/database/FirebaseObject.js
@@ -461,11 +461,13 @@
         var isResolved = false;
         var def = $q.defer();
         var applyUpdate = $firebaseUtils.batch(function(snap) {
-          var changed = firebaseObject.$$updated(snap);
-          if( changed ) {
-            // notifies $watch listeners and
-            // updates $scope if bound to a variable
-            firebaseObject.$$notify();
+          if (firebaseObject) {
+            var changed = firebaseObject.$$updated(snap);
+            if( changed ) {
+              // notifies $watch listeners and
+              // updates $scope if bound to a variable
+              firebaseObject.$$notify();
+            }
           }
         });
         var error = $firebaseUtils.batch(function(err) {


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Make sure your changes pass our linter and the tests all pass on your local machine. We've hooked
up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->


### Description

Fix a bug, which was triggered when a node set to null while the firebaseObject is on it.
the on('value') got triggered with snap value null, which call the applyUpdate method, and it delay the call with angular's $evalAsync method, but when that code finally be called, the firebaseObject was already set to null due to the destroy call.

the similar fix was already added to the error callback just below this code block, should also add to this update callback.

<!-- Are you fixing a bug? Updating our documentation? Implementing a new feature? Make sure we
have the context around your change. Link to other relevant issues or pull requests. -->

<!-- Proposing an API change? Provide code samples showing how the API will be used. -->
