### PR TITLE
Fix unbound methods on upload task from $firebaseStorage (#925)

### DIFF
--- a/src/storage/FirebaseStorage.js
+++ b/src/storage/FirebaseStorage.js
@@ -34,11 +34,11 @@
           });
         });
       },
-      $cancel: task.cancel,
-      $resume: task.resume,
-      $pause: task.pause,
-      then: task.then,
-      catch: task.catch,
+      $cancel: task.cancel.bind(task),
+      $resume: task.resume.bind(task),
+      $pause: task.pause.bind(task),
+      then: task.then.bind(task),
+      catch: task.catch.bind(task),
       $snapshot: task.snapshot
     };
   }

--- a/tests/protractor/upload/upload.html
+++ b/tests/protractor/upload/upload.html
@@ -23,12 +23,17 @@
       <button id="submit" ng-click="upload()">Submit</button>
     </div>
 
+    <p ng-show="isCanceled" id="canceled">
+      Canceled
+    </p>
+
     <div ng-show="isUploading" id="uploading">
-      {{(metadata.bytesTransferred / metadata.totalBytes)*100}}%<br />
+      <button id="cancel" ng-click="cancel()">Cancel</button>
+      {{((metadata.bytesTransferred / metadata.totalBytes)*100) || 0}}%<br />
     </div>
 
     <br />
-    <div ng-show="metadata.downloadURL" id="url">{{metadata.downloadURL}}</div>
+    <div ng-show="metadata.downloadURL && snapshot" id="url">{{metadata.downloadURL}}</div>
 
     <div ng-show="error">
       {{ error | json }}

--- a/tests/protractor/upload/upload.manual.js
+++ b/tests/protractor/upload/upload.manual.js
@@ -50,18 +50,37 @@ describe('Upload App', function () {
     expect(browser.getTitle()).toEqual('AngularFire Upload e2e Test');
   });
 
-  it('uploads a file', function (done) {
+  it('uploads a file, cancels the upload task, and tries uploading again', function (done) {
     var fileToUpload = './upload/logo.png';
     var absolutePath = path.resolve(__dirname, fileToUpload);
 
     $('input[type="file"]').sendKeys(absolutePath);
     $('#submit').click();
 
-    var el = element(by.id('url'));
-    browser.driver.wait(protractor.until.elementIsVisible(el))
+    var el;
+    var cancelEl = element(by.id('cancel'));
+
+    browser.driver.wait(protractor.until.elementIsVisible(cancelEl.getWebElement()))
+      .then(function () {
+          $('#cancel').click();
+
+        var canceledEl = element(by.id('canceled'));
+        return browser.driver.wait(protractor.until.elementIsVisible(canceledEl.getWebElement()))
+      })
+      .then(function () {
+        var submitEl = element(by.id('submit'));
+        return browser.driver.wait(protractor.until.elementIsVisible(submitEl.getWebElement()))
+      })
+      .then(function () {
+        $('#submit').click();
+
+        el = element(by.id('url'));
+        return browser.driver.wait(protractor.until.elementIsVisible(el.getWebElement()))
+      })
       .then(function () {
         return el.getText();
-      }).then(function (text) {
+      })
+      .then(function (text) {
         var result = "https://firebasestorage.googleapis.com/v0/b/oss-test.appspot.com/o/user%2F1.png";
         expect(text.slice(0, result.length)).toEqual(result);
         done();


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Make sure your changes pass our linter and the tests all pass on your local machine. We've hooked
up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->


### Description

<!-- Are you fixing a bug? Updating our documentation? Implementing a new feature? Make sure we
have the context around your change. Link to other relevant issues or pull requests. -->

Sorry took me so long. This should fix #925. This is the first code contribution so if I did anything wrong please tell me :D

### Code sample

Now this code should run correctly:

```js
const imageStorageRef = firebase.storage().ref('images')
const imageStorage = $firebaseStorage(imageStorageRef)
const uploadTask = imageStorage.$putString(image, 'base64')

uploadTask.then((snap) => {
  console.log('downloadURL:', snap.downloadURL)
})

// Also .catch(), .$pause(), .$resume(), and .$cancel() should work as expected.
```
