### PR TITLE
feat(auth): Add ability to link user with email credentials to current user

### DIFF
--- a/src/auth/FirebaseAuth.js
+++ b/src/auth/FirebaseAuth.js
@@ -59,6 +59,7 @@
         $updateEmail: this.updateEmail.bind(this),
         $deleteUser: this.deleteUser.bind(this),
         $sendPasswordResetEmail: this.sendPasswordResetEmail.bind(this),
+        $linkUser: this.linkUser.bind(this),
 
         // Hack: needed for tests
         _: this
@@ -332,6 +333,26 @@
       } else {
         return this._q.reject("Cannot delete user since there is no logged in user.");
       }
+    },
+
+    /**
+     * Links the currently logged in user to a user with the given credentials.
+     *
+     * @param {string} email User's email
+     * @param {string} password User's password
+     * @return {Promise<firebase.User>} A promise fulfilled with the `firebase.User` object.
+     */
+    linkUser: function(email, password) {
+      var user = this.getAuth(),
+          credential;
+
+      if (!user) {
+        throw new Error('No user to link to (user must login before linking)');
+      }
+
+      credential = firebase.auth.EmailAuthProvider.credential(email, password);
+
+      return user.link(credential);
     },
 
 


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Make sure your changes pass our linter and the tests all pass on your local machine. We've hooked
up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->


### Description

<!-- Are you fixing a bug? Updating our documentation? Implementing a new feature? Make sure we
have the context around your change. Link to other relevant issues or pull requests. -->
Adding the ability to link a user to a new user with email and password.

### Code sample

<!-- Proposing an API change? Provide code samples showing how the API will be used. -->
```js
angular.module('some-module', ['firebase'])
  .controller('MyCtrl', function MyCtrl($fireabseAuth) {
    this.authObj = $firebaseAuth();
    // ... Assuming user logged in somehow. Anonymously, or with other credentials
    this.user = this.authObj.$getAuth();

    // ... other logic ...

    // This could be linked to some `ng-click` for example
    this.linkUser = function (email, password) {
        this.authObj.$linkUser(email, password)
            .then(function (authData) {
                // This will not trigger a `$digest`, so do so if needed using `$timeout`, `$scope.$apply` or whatever suits you.
                this.user = authData;
            }.bind(this));
    };

    // Another way to get the user: listening to `$onAuthStateChanged`
    this.authObj.$onAuthStateChanged(function(firebaseUser) {
      if (firebaseUser) {
        console.log("Signed in as:", firebaseUser.uid);
        this.user = firebaseUser;
      } else {
        console.log("Signed out");
        this.user = undefined;
      }
    });
  });
```

Add the `$linkUser` method. #764