### PR TITLE
child() method missing

### DIFF
--- a/docs/guide/synchronized-arrays.md
+++ b/docs/guide/synchronized-arrays.md
@@ -142,7 +142,7 @@ var app = angular.module("sampleApp", ["firebase"]);
 app.factory("chatMessages", ["$firebaseArray",
   function($firebaseArray) {
     // create a reference to the database where we will store our data
-    var ref = firebase.database().ref();
+    var ref = firebase.database().ref().child("messages");
 
     return $firebaseArray(ref);
   }


### PR DESCRIPTION


<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Make sure your changes pass our linter and the tests all pass on your local machine. We've hooked
up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->


### Description
The call to child("messages") method is missing in line 145 thus, the Controller (ChatCtrl) won't be able to get the messages collection
<!-- Are you fixing a bug? Updating our documentation? Implementing a new feature? Make sure we
have the context around your change. Link to other relevant issues or pull requests. -->

### Code sample
var ref = firebase.database().ref().child("messages");
<!-- Proposing an API change? Provide code samples showing how the API will be used. -->
