### PR TITLE
Add tests for _initAuthResolver in FirebaseAuth

### DIFF
--- a/tests/unit/FirebaseAuth.spec.js
+++ b/tests/unit/FirebaseAuth.spec.js
@@ -681,4 +681,24 @@ describe('FirebaseAuth',function(){
       expect(result).toEqual('myResult');
     });
   });
+
+  describe('_initAuthResolver',function(){
+    it('should return a promise', function() {
+      var ctx = authService._;
+      expect(ctx._initAuthResolver()).toBeAPromise();
+    });
+
+    it('should resolve when the inital auth state is fetched', function(done){
+      var ctx = authService._;
+      var promise = ctx._initAuthResolver();
+      wrapPromise(promise);
+      promise.then(function() {
+        expect(status).toBe('resolved');
+        done();
+      });
+
+      fakePromiseResolve();
+    });
+  });
+
 });

--- a/tests/unit/FirebaseAuth.spec.js
+++ b/tests/unit/FirebaseAuth.spec.js
@@ -698,6 +698,7 @@ describe('FirebaseAuth',function(){
       });
 
       fakePromiseResolve();
+      tick();
     });
   });
 


### PR DESCRIPTION
### Description
`src/auth/FirebaseAuth.js` contains a function named `_initAuthResolver`
This pr adds unit test cases for `_initAuthResolver` function.
Reference: https://github.com/firebase/angularfire/issues/951